### PR TITLE
Fix: errors logged via Ember.onerror have empty message

### DIFF
--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -54,9 +54,9 @@ export default Ember.Service.extend({
     if (this.get('enabled')) {
       let oldOnError = Ember.onerror || function() {};
 
-      Ember.onerror = () => {
-        oldOnError(...arguments);
-        this.error(...arguments);
+      Ember.onerror = (...args) => {
+        oldOnError(...args);
+        this.error(...args);
       };
     }
   }

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -54,9 +54,9 @@ export default Ember.Service.extend({
     if (this.get('enabled')) {
       let oldOnError = Ember.onerror || function() {};
 
-      Ember.onerror = (error) => {
-        oldOnError(error);
-        this.error(error.message, error);
+      Ember.onerror = (...args) => {
+        oldOnError(...args);
+        this.error(...args);
       };
     }
   }

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -54,9 +54,9 @@ export default Ember.Service.extend({
     if (this.get('enabled')) {
       let oldOnError = Ember.onerror || function() {};
 
-      Ember.onerror = (...args) => {
-        oldOnError(...args);
-        this.error(...args);
+      Ember.onerror = (error) => {
+        oldOnError(error);
+        this.error(error.message, error);
       };
     }
   }

--- a/tests/unit/instance-initializers/rollbar-test.js
+++ b/tests/unit/instance-initializers/rollbar-test.js
@@ -18,27 +18,14 @@ module('Unit | Instance Initializer | rollbar', {
 
 function createRollbarMock(assert) {
   return Ember.Object.extend({
-    error() {
+    registerLogger() {
       assert.ok(true);
     }
   });
 }
 
-test('register error handler for Ember errors', function(assert) {
+test('invokes registerLogger', function(assert) {
   assert.expect(1);
   this.appInstance.register('service:rollbar', createRollbarMock(assert))
   initialize(this.appInstance);
-  Ember.onerror();
-});
-
-test('error handler does not override previous hook', function(assert) {
-  assert.expect(2);
-  this.appInstance.register('service:rollbar', createRollbarMock(assert))
-
-  Ember.onerror = function() {
-    assert.ok(true);
-  }
-
-  initialize(this.appInstance);
-  Ember.onerror();
 });

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -47,37 +47,41 @@ test('debug', function(assert) {
 });
 
 test('registerLogger: register error handler for Ember errors if enabled', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
+  let error = new Error('foo');
   let service = this.subject({
     config: {
       enabled: true
     },
-    error(message) {
+    error(message, error) {
       assert.ok(true, 'error handler is called');
-      assert.equal(message, 'foo', 'error is passed to error handler as argument');
+      assert.equal(message, 'foo', 'error messages is passed to error handler as first argument');
+      assert.equal(error, error, 'error object is passed to error handler as second argument');
     }
   });
   service.registerLogger();
-  Ember.onerror('foo');
+  Ember.onerror(error);
 });
 
 test('registerLogger: does not override previous hook', function(assert) {
-  assert.expect(4);
+  assert.expect(5);
+  let error = new Error('foo');
   let service = this.subject({
     config: {
       enabled: true
     },
-    error(message) {
+    error(message, error) {
       assert.ok(true, 'rollbar error handler is called');
-      assert.equal(message, 'foo', 'error is passed to rollbar error handler as argument');
+      assert.equal(message, 'foo', 'error message is passed to rollbar error handler as first argument');
+      assert.equal(error, error, 'error object is passed to rollbar error handler as second argument');
     }
   });
-  Ember.onerror = function(message) {
+  Ember.onerror = function(error) {
     assert.ok(true, 'previous hook is called');
-    assert.equal(message, 'foo', 'error is passed to previous hook as argument');
+    assert.equal(error, error, 'error object is passed to previous hook as first argument');
   };
   service.registerLogger();
-  Ember.onerror('foo');
+  Ember.onerror(error);
 });
 
 test('registerLogger: does not register logger if disabled', function(assert) {

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 import Rollbar from 'rollbar';
 
 moduleFor('service:rollbar', 'Unit | Service | rollbar', {
@@ -44,3 +45,54 @@ test('debug', function(assert) {
   let uuid = service.debug('My error message').uuid;
   assert.ok(uuid);
 });
+
+test('registerLogger: register error handler for Ember errors if enabled', function(assert) {
+  assert.expect(2);
+  let service = this.subject({
+    config: {
+      enabled: true
+    },
+    error(message) {
+      assert.ok(true, 'error handler is called');
+      assert.equal(message, 'foo', 'error is passed to error handler as argument');
+    }
+  });
+  service.registerLogger();
+  Ember.onerror('foo');
+});
+
+test('registerLogger: does not override previous hook', function(assert) {
+  assert.expect(4);
+  let service = this.subject({
+    config: {
+      enabled: true
+    },
+    error(message) {
+      assert.ok(true, 'rollbar error handler is called');
+      assert.equal(message, 'foo', 'error is passed to rollbar error handler as argument');
+    }
+  });
+  Ember.onerror = function(message) {
+    assert.ok(true, 'previous hook is called');
+    assert.equal(message, 'foo', 'error is passed to previous hook as argument');
+  };
+  service.registerLogger();
+  Ember.onerror('foo');
+});
+
+test('registerLogger: does not register logger if disabled', function(assert) {
+  assert.expect(1);
+  let service = this.subject({
+    config: {
+      enabled: false
+    },
+    error() {
+      assert.notOk(true);
+    }
+  });
+  Ember.onerror = function() {
+    assert.ok(true);
+  };
+  service.registerLogger();
+  Ember.onerror();
+})

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -47,41 +47,37 @@ test('debug', function(assert) {
 });
 
 test('registerLogger: register error handler for Ember errors if enabled', function(assert) {
-  assert.expect(3);
-  let error = new Error('foo');
+  assert.expect(2);
   let service = this.subject({
     config: {
       enabled: true
     },
-    error(message, error) {
+    error(message) {
       assert.ok(true, 'error handler is called');
-      assert.equal(message, 'foo', 'error messages is passed to error handler as first argument');
-      assert.equal(error, error, 'error object is passed to error handler as second argument');
+      assert.equal(message, 'foo', 'error is passed to error handler as argument');
     }
   });
   service.registerLogger();
-  Ember.onerror(error);
+  Ember.onerror('foo');
 });
 
 test('registerLogger: does not override previous hook', function(assert) {
-  assert.expect(5);
-  let error = new Error('foo');
+  assert.expect(4);
   let service = this.subject({
     config: {
       enabled: true
     },
-    error(message, error) {
+    error(message) {
       assert.ok(true, 'rollbar error handler is called');
-      assert.equal(message, 'foo', 'error message is passed to rollbar error handler as first argument');
-      assert.equal(error, error, 'error object is passed to rollbar error handler as second argument');
+      assert.equal(message, 'foo', 'error is passed to rollbar error handler as argument');
     }
   });
-  Ember.onerror = function(error) {
+  Ember.onerror = function(message) {
     assert.ok(true, 'previous hook is called');
-    assert.equal(error, error, 'error object is passed to previous hook as first argument');
+    assert.equal(message, 'foo', 'error is passed to previous hook as argument');
   };
   service.registerLogger();
-  Ember.onerror(error);
+  Ember.onerror('foo');
 });
 
 test('registerLogger: does not register logger if disabled', function(assert) {


### PR DESCRIPTION
Arrow functions does not bind arguments. Therefor `error()` was called
with `arguments` of `registerLogger()` and not `Ember.onerror()`.
Bug was introduced by 607d4243908f3ff5e2a2284b0331167cec40bb62 (v0.3.3).

Also fixed tests and added new ones to address this bug.