### PR TITLE
Updated rollbar to v2.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-rollbar-client",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -279,12 +279,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -432,7 +426,7 @@
       "dev": true,
       "requires": {
         "cson-parser": "1.3.5",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash": "3.10.1"
       },
       "dependencies": {
@@ -445,9 +439,9 @@
       }
     },
     "aproba": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -586,12 +580,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -599,9 +587,9 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "ast-traverse": {
@@ -633,16 +621,9 @@
         "heimdalljs": "0.2.5",
         "istextorbinary": "2.1.0",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "username-sync": "1.0.1"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "async-each": {
@@ -666,15 +647,6 @@
         "debug": "2.6.8"
       }
     },
-    "async-some": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
-      "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -688,9 +660,9 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
@@ -1353,7 +1325,7 @@
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.17"
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1430,57 +1402,18 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
-      "integrity": "sha1-s2p/ERE4U6NCoVaR2Y4tzIpswnA=",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "cache-base": "0.8.5",
+        "cache-base": "1.0.1",
         "class-utils": "0.3.5",
         "component-emitter": "1.2.1",
-        "define-property": "0.2.5",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
         "mixin-deep": "1.2.0",
         "pascalcase": "0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
-        }
       }
     },
     "base64-arraybuffer": {
@@ -1588,12 +1521,12 @@
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "bootstrap-sass": {
@@ -1603,9 +1536,9 @@
       "dev": true
     },
     "bower-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
-      "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+      "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -1666,14 +1599,6 @@
         "json-stable-stringify": "1.0.1",
         "minimatch": "3.0.4",
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-asset-rewrite": {
@@ -1718,15 +1643,10 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         }
       }
     },
@@ -1907,17 +1827,9 @@
         "heimdalljs": "0.2.5",
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "silent-error": "1.1.0"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-caching-writer": {
@@ -1929,17 +1841,9 @@
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "broccoli-plugin": "1.3.0",
         "debug": "2.6.8",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-clean-css": {
@@ -2017,7 +1921,7 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         }
       }
@@ -2057,7 +1961,7 @@
             "broccoli-kitchen-sink-helpers": "0.2.9",
             "broccoli-plugin": "1.1.0",
             "debug": "2.6.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "rsvp": "3.6.2",
             "walk-sync": "0.2.7"
           }
@@ -2080,7 +1984,7 @@
           "requires": {
             "promise-map-series": "0.2.3",
             "quick-temp": "0.1.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8"
           }
         },
@@ -2097,12 +2001,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
@@ -2110,7 +2008,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -2130,14 +2028,6 @@
         "rsvp": "3.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-funnel": {
@@ -2155,7 +2045,7 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "path-posix": "1.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
       }
@@ -2198,7 +2088,7 @@
         "aot-test-generators": "0.1.0",
         "broccoli-concat": "3.2.2",
         "broccoli-persistent-filter": "1.4.3",
-        "eslint": "4.6.1",
+        "eslint": "4.7.1",
         "json-stable-stringify": "1.0.1",
         "lodash.defaultsdeep": "4.6.0",
         "md5-hex": "2.0.0"
@@ -2215,7 +2105,7 @@
         "fs-tree-diff": "0.5.6",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -2243,17 +2133,10 @@
         "heimdalljs-logger": "0.1.9",
         "mkdirp": "0.5.1",
         "promise-map-series": "0.2.3",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "broccoli-plugin": {
@@ -2263,7 +2146,7 @@
       "requires": {
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -2302,12 +2185,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
           "dev": true
         }
       }
@@ -2348,7 +2225,7 @@
             "broccoli-kitchen-sink-helpers": "0.2.9",
             "broccoli-plugin": "1.1.0",
             "debug": "2.6.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "rsvp": "3.6.2",
             "walk-sync": "0.2.7"
           }
@@ -2371,7 +2248,7 @@
           "requires": {
             "promise-map-series": "0.2.3",
             "quick-temp": "0.1.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8"
           }
         },
@@ -2388,12 +2265,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
@@ -2401,7 +2272,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -2445,7 +2316,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -2459,12 +2330,6 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -2477,7 +2342,7 @@
         "broccoli-plugin": "1.3.0",
         "debug": "2.6.8",
         "lodash.merge": "4.6.0",
-        "matcher-collection": "1.0.4",
+        "matcher-collection": "1.0.5",
         "mkdirp": "0.5.1",
         "source-map-url": "0.3.0",
         "symlink-or-copy": "1.1.8",
@@ -2504,8 +2369,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
       "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000726",
-        "electron-to-chromium": "1.3.20"
+        "caniuse-lite": "1.0.30000733",
+        "electron-to-chromium": "1.3.21"
       }
     },
     "bser": {
@@ -2564,21 +2429,20 @@
       "dev": true
     },
     "cache-base": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
-      "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "0.2.3",
+        "collection-visit": "1.0.0",
         "component-emitter": "1.2.1",
         "get-value": "2.0.6",
-        "has-value": "0.3.1",
+        "has-value": "1.0.0",
         "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "set-value": "0.4.3",
+        "set-value": "2.0.0",
         "to-object-path": "0.3.0",
-        "union-value": "0.2.4",
-        "unset-value": "0.1.2"
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "calculate-cache-key-for-tree": {
@@ -2650,15 +2514,15 @@
       "dev": true,
       "requires": {
         "browserslist": "2.4.0",
-        "caniuse-lite": "1.0.30000726",
+        "caniuse-lite": "1.0.30000733",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000726",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000726.tgz",
-      "integrity": "sha1-lmp1P6EHoJ1BMc+LPWFnI6Bsz34="
+      "version": "1.0.30000733",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000733.tgz",
+      "integrity": "sha1-6/xIJUEXzAxmGXpFNstDl6bPvM0="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -2667,14 +2531,6 @@
       "dev": true,
       "requires": {
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "cardinal": {
@@ -2787,12 +2643,6 @@
         }
       }
     },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
-    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -2831,12 +2681,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -2990,14 +2834,13 @@
       "dev": true
     },
     "collection-visit": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-      "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "lazy-cache": "2.0.2",
-        "map-visit": "0.1.5",
-        "object-visit": "0.3.4"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -3049,7 +2892,7 @@
         "detective": "4.5.0",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "mkdirp": "0.5.1",
         "private": "0.1.7",
         "q": "1.5.0",
@@ -3232,9 +3075,9 @@
       "dev": true
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "continuable-cache": {
@@ -3347,12 +3190,23 @@
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "crypto-random-string": {
@@ -3410,14 +3264,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "debug": {
@@ -3528,7 +3374,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3585,16 +3431,6 @@
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         }
-      }
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
       }
     },
     "diff": {
@@ -3692,9 +3528,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.20",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.20.tgz",
-      "integrity": "sha1-Lu3VzLrn3cVX9orR/OnBcukV5OU="
+      "version": "1.3.21",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz",
+      "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI="
     },
     "ember-ajax": {
       "version": "3.0.0",
@@ -3755,7 +3591,7 @@
         "ember-runtime-enumerable-includes-polyfill": "2.0.0",
         "ember-wormhole": "0.5.2",
         "findup-sync": "2.0.0",
-        "fs-extra": "4.0.1",
+        "fs-extra": "4.0.2",
         "rsvp": "4.0.1",
         "silent-error": "1.1.0"
       },
@@ -3786,7 +3622,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -3812,6 +3648,12 @@
             "supports-color": "4.4.0"
           }
         },
+        "rsvp": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.0.1.tgz",
+          "integrity": "sha512-EzazW+1W0MqpfPBhApGcKU2xbEuzgs+rO4FvcvuRN1OtLxNFgf9Ce31WGXwGk4VyQQzU8hNyRLjHMzJt+D0STw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -3831,7 +3673,7 @@
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower-config": "1.4.0",
+        "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.2",
         "broccoli-brocfile-loader": "0.18.0",
@@ -3863,7 +3705,7 @@
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-preprocess-registry": "3.1.1",
         "ember-cli-string-utils": "1.1.0",
-        "ember-try": "0.2.16",
+        "ember-try": "0.2.17",
         "ensure-posix-path": "1.0.2",
         "execa": "0.7.0",
         "exists-sync": "0.0.4",
@@ -3884,7 +3726,7 @@
         "inflection": "1.12.0",
         "is-git-url": "1.0.0",
         "isbinaryfile": "3.0.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "leek": "0.0.24",
         "lodash.template": "4.4.0",
@@ -3932,7 +3774,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -3980,12 +3822,6 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -4024,7 +3860,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -4042,14 +3878,6 @@
         "heimdalljs-logger": "0.1.9",
         "rsvp": "3.6.2",
         "sane": "1.7.0"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-cli-build-config-editor": {
@@ -4091,7 +3919,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -4119,14 +3947,6 @@
         "ember-cli-version-checker": "2.0.0",
         "rsvp": "3.6.2",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-cli-favicon": {
@@ -4250,7 +4070,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4368,12 +4188,6 @@
           "requires": {
             "is-finite": "1.0.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
@@ -4529,7 +4343,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4648,12 +4462,6 @@
             "is-finite": "1.0.2"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -4762,14 +4570,8 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -4827,7 +4629,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4897,12 +4699,6 @@
         "silent-error": "1.1.0"
       },
       "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -4940,7 +4736,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5087,7 +4883,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5150,7 +4946,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5347,7 +5143,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -5478,12 +5274,6 @@
           "requires": {
             "is-finite": "1.0.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
@@ -5628,7 +5418,7 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5652,12 +5442,6 @@
             "semver": "5.4.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "simple-html-tokenizer": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
@@ -5673,9 +5457,9 @@
       "dev": true
     },
     "ember-try": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.16.tgz",
-      "integrity": "sha512-AQZEwMv6BIrVq/ysRcWULvw5tr6RQtUfSYuCpvtdxxJWho74d16YKhGyWAdID+QSmWHrVVGx+O1kDgjf7YKu9A==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.17.tgz",
+      "integrity": "sha1-D//2h2MCkbTPlPWxlucowaktiuw=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -5688,7 +5472,7 @@
         "fs-extra": "0.26.7",
         "promise-map-series": "0.2.3",
         "resolve": "1.4.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
       },
@@ -5718,14 +5502,8 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -5736,17 +5514,9 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "node-fetch": "1.7.2",
+        "node-fetch": "1.7.3",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-wormhole": {
@@ -5804,7 +5574,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18"
+        "iconv-lite": "0.4.19"
       }
     },
     "engine.io": {
@@ -5972,9 +5742,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
-      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.1.tgz",
+      "integrity": "sha1-hJgEE2lT6+NmeC+fhhHiy9G1RoE=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
@@ -5982,10 +5752,10 @@
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
+        "debug": "3.0.1",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -5995,9 +5765,9 @@
         "globals": "9.18.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.3",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -6006,7 +5776,7 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
@@ -6017,9 +5787,9 @@
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
           "dev": true
         },
         "ansi-regex": {
@@ -6057,15 +5827,24 @@
             "restore-cursor": "2.0.0"
           }
         },
-        "external-editor": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-          "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.18",
+            "ms": "2.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+          "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19",
             "jschardet": "1.5.1",
-            "tmp": "0.0.31"
+            "tmp": "0.0.33"
           }
         },
         "figures": {
@@ -6078,16 +5857,16 @@
           }
         },
         "inquirer": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
-          "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "2.0.0",
+            "ansi-escapes": "3.0.0",
             "chalk": "2.1.0",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
-            "external-editor": "2.0.4",
+            "external-editor": "2.0.5",
             "figures": "2.0.0",
             "lodash": "4.17.4",
             "mute-stream": "0.0.7",
@@ -6159,9 +5938,9 @@
           }
         },
         "tmp": {
-          "version": "0.0.31",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-          "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2"
@@ -6180,9 +5959,9 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -6226,9 +6005,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter3": {
@@ -6244,9 +6023,9 @@
       "dev": true
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
@@ -6330,12 +6109,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -6408,20 +6181,20 @@
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.8",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.4",
+        "etag": "1.8.1",
+        "finalhandler": "1.0.5",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "1.1.5",
         "qs": "6.5.0",
@@ -6472,66 +6245,19 @@
       }
     },
     "extglob": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-1.1.0.tgz",
-      "integrity": "sha1-Bni04s5FwOTlD15er7Gw2rW05CQ=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.2.tgz",
+      "integrity": "sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==",
       "dev": true,
       "requires": {
         "array-unique": "0.3.2",
-        "define-property": "0.2.5",
+        "define-property": "1.0.0",
         "expand-brackets": "2.1.4",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
-        "to-regex": "2.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
-        },
-        "to-regex": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz",
-          "integrity": "sha1-4606QM/hGVWaBa6kPkyu+sxekB0=",
-          "dev": true,
-          "requires": {
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "regex-not": "0.1.2"
-          },
-          "dependencies": {
-            "regex-not": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz",
-              "integrity": "sha1-vH8cSUSxGINT0H3uuRK5TgreJds=",
-              "dev": true
-            }
-          }
-        }
+        "to-regex": "3.0.1"
       }
     },
     "extract-zip": {
@@ -6650,7 +6376,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "has-ansi": {
@@ -6661,12 +6387,6 @@
           "requires": {
             "ansi-regex": "0.2.1"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
@@ -6755,7 +6475,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -6827,16 +6547,16 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
+      "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
@@ -6873,7 +6593,7 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.0.4",
+        "micromatch": "3.1.0",
         "resolve-dir": "1.0.1"
       }
     },
@@ -6947,9 +6667,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
@@ -6958,9 +6678,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
@@ -6985,20 +6705,20 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
-      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       },
       "dependencies": {
         "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -7023,18 +6743,6 @@
         "symlink-or-copy": "1.1.8"
       }
     },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "1.0.34"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7053,15 +6761,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7071,21 +6777,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7095,49 +6798,42 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7146,8 +6842,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -7155,8 +6850,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -7164,8 +6858,7 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -7174,34 +6867,29 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -7209,26 +6897,22 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7237,8 +6921,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7247,8 +6930,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7256,8 +6938,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7266,28 +6947,24 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7296,28 +6973,24 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7328,14 +7001,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -7346,8 +7017,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7358,8 +7028,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7375,8 +7044,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7385,8 +7053,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7394,8 +7061,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7408,21 +7074,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7432,15 +7095,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7452,14 +7113,12 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7470,8 +7129,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -7480,21 +7138,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -7502,28 +7157,24 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7532,22 +7183,19 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7556,22 +7204,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7583,8 +7228,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7592,14 +7236,12 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -7607,8 +7249,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -7616,14 +7257,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7631,15 +7270,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7656,8 +7293,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7667,8 +7303,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7680,28 +7315,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -7709,22 +7340,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7734,41 +7362,35 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7780,8 +7402,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7789,8 +7410,7 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -7804,8 +7424,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7835,8 +7454,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -7844,35 +7462,30 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7881,8 +7494,7 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7899,8 +7511,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7908,8 +7519,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -7919,8 +7529,7 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -7928,15 +7537,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -7944,15 +7551,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -7962,8 +7567,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7979,8 +7583,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7989,8 +7592,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7999,35 +7601,30 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8036,8 +7633,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8046,8 +7642,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -8061,28 +7656,7 @@
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
-    },
-    "fstream-npm": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.0.7.tgz",
-      "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
-      "dev": true,
-      "requires": {
-        "fstream-ignore": "1.0.5",
-        "inherits": "2.0.3"
+        "rimraf": "2.6.2"
       }
     },
     "functional-red-black-tree": {
@@ -8097,7 +7671,7 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.2",
+        "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
         "has-unicode": "2.0.1",
         "object-assign": "4.1.1",
@@ -8147,14 +7721,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "git-repo-info": {
@@ -8350,31 +7916,19 @@
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        }
+        "ajv": "5.2.2",
+        "har-schema": "2.0.0"
       }
     },
     "harmony-reflect": {
@@ -8427,32 +7981,36 @@
       "dev": true
     },
     "has-value": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
         "get-value": "2.0.6",
-        "has-values": "0.1.4",
-        "isobject": "2.1.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
     },
     "hash-for-dep": {
       "version": "1.2.0",
@@ -8476,15 +8034,15 @@
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
       }
     },
     "heimdalljs": {
@@ -8528,9 +8086,9 @@
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
       "dev": true
     },
     "home-or-tmp": {
@@ -8618,6 +8176,12 @@
         "statuses": "1.3.1"
       }
     },
+    "http-parser-js": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
+      "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU=",
+      "dev": true
+    },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
@@ -8629,26 +8193,20 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-      "dev": true
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
@@ -8870,14 +8428,6 @@
         "is-accessor-descriptor": "0.1.6",
         "is-data-descriptor": "0.1.4",
         "kind-of": "5.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
-        }
       }
     },
     "is-dotfile": {
@@ -9145,7 +8695,7 @@
         "pixelmatch": "4.0.2",
         "pngjs": "3.3.0",
         "read-chunk": "1.0.1",
-        "request": "2.81.0",
+        "request": "2.82.0",
         "stream-to-buffer": "0.1.0",
         "tinycolor2": "1.4.1",
         "url-regex": "3.2.0"
@@ -9164,9 +8714,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
     },
     "js-reporters": {
@@ -9181,9 +8731,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -9207,12 +8757,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -9280,14 +8824,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "kew": {
@@ -9297,13 +8833,10 @@
       "dev": true
     },
     "kind-of": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
+      "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
@@ -9341,14 +8874,6 @@
         "debug": "2.6.8",
         "lodash.assign": "3.2.0",
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "leven": {
@@ -9835,24 +9360,6 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -9992,13 +9499,12 @@
       "dev": true
     },
     "map-visit": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-      "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "lazy-cache": "2.0.2",
-        "object-visit": "0.3.4"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-it": {
@@ -10039,9 +9545,9 @@
       }
     },
     "matcher-collection": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
-      "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
       "requires": {
         "minimatch": "3.0.4"
       }
@@ -10147,7 +9653,7 @@
         "fs-tree-diff": "0.5.6",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -10158,9 +9664,9 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.0.4.tgz",
-      "integrity": "sha1-FUPx0EgTRHrIUgAcX1qTNAF4bR0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.0.tgz",
+      "integrity": "sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -10168,10 +9674,10 @@
         "braces": "2.2.2",
         "define-property": "1.0.0",
         "extend-shallow": "2.0.1",
-        "extglob": "1.1.0",
+        "extglob": "2.0.2",
         "fragment-cache": "0.2.1",
-        "kind-of": "4.0.0",
-        "nanomatch": "1.2.0",
+        "kind-of": "5.0.2",
+        "nanomatch": "1.2.3",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
@@ -10308,9 +9814,9 @@
       "dev": true
     },
     "nanomatch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.0.tgz",
-      "integrity": "sha1-dv2z1K52F+N3GeekBHuECFfAyxw=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.3.tgz",
+      "integrity": "sha512-HqDMQWJlwpXbfKDpAnkc6AJQh5PFqVlrjYbruDjYVAS+05TQUb1qhIde4G9jMzHbs/u6bgEok1jMAV4yJzoh+w==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -10318,9 +9824,8 @@
         "define-property": "1.0.0",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
-        "is-extglob": "2.1.1",
         "is-odd": "1.0.0",
-        "kind-of": "4.0.0",
+        "kind-of": "5.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
@@ -10340,9 +9845,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -10363,8 +9868,8 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
+        "request": "2.82.0",
+        "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
         "which": "1.3.0"
@@ -10450,7 +9955,7 @@
         "nan": "2.7.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.81.0",
+        "request": "2.82.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
       },
@@ -10528,21 +10033,21 @@
         "async-some": "1.0.2",
         "chownr": "1.0.1",
         "cmd-shim": "2.0.1",
-        "columnify": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+        "columnify": "1.5.4",
         "config-chain": "1.1.9",
         "debuglog": "1.0.1",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
         "fs-vacuum": "1.2.7",
-        "fs-write-stream-atomic": "1.0.10",
+        "fs-write-stream-atomic": "1.0.8",
         "fstream": "1.0.8",
         "fstream-npm": "1.0.7",
-        "glob": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+        "glob": "6.0.3",
         "graceful-fs": "4.1.2",
-        "has-unicode": "file:../has-unicode",
-        "hosted-git-info": "2.1.5",
+        "has-unicode": "2.0.0",
+        "hosted-git-info": "2.1.4",
         "iferr": "0.1.5",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "imurmurhash": "0.1.4",
         "inflight": "1.0.4",
         "inherits": "2.0.1",
         "ini": "1.3.4",
@@ -10563,32 +10068,32 @@
         "lodash.uniq": "3.2.2",
         "lodash.without": "3.2.1",
         "mkdirp": "0.5.1",
-        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "node-gyp": "3.2.1",
+        "nopt": "3.0.6",
         "normalize-git-url": "3.0.1",
         "normalize-package-data": "2.3.5",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "2.0.1",
-        "npm-package-arg": "4.1.1",
+        "npm-package-arg": "4.1.0",
         "npm-registry-client": "7.0.9",
         "npm-user-validate": "0.1.2",
-        "npmlog": "2.0.4",
-        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+        "npmlog": "2.0.0",
+        "once": "1.3.3",
         "opener": "1.4.1",
         "osenv": "0.1.3",
         "path-is-inside": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
+        "read-package-json": "2.0.2",
         "read-package-tree": "5.1.2",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+        "readable-stream": "2.0.5",
         "readdir-scoped-modules": "1.0.2",
-        "realize-package-specifier": "3.0.3",
-        "request": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+        "realize-package-specifier": "3.0.1",
+        "request": "2.67.0",
         "retry": "0.8.0",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+        "rimraf": "2.5.0",
+        "semver": "5.1.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "1.0.0",
@@ -10597,61 +10102,61 @@
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
-        "unique-filename": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+        "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "2.2.2",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
+        "which": "1.2.1",
         "wrappy": "1.0.1",
         "write-file-atomic": "1.1.4"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+          "bundled": true,
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.1.tgz",
-          "integrity": "sha1-xKwsxb7PuLCZ3n758CeQ59Mtme8=",
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
+        },
+        "async-some": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3"
+          }
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz",
-          "integrity": "sha1-RRKjc9I5FnmuxRrR1HM1Wem4XUo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "3.0.8",
@@ -10660,15 +10165,14 @@
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "columnify": {
-          "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "version": "1.5.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "3.0.0",
@@ -10677,8 +10181,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "defaults": "1.0.3"
@@ -10686,8 +10189,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "clone": "1.0.2"
@@ -10695,8 +10197,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10707,8 +10208,7 @@
         },
         "config-chain": {
           "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-          "integrity": "sha1-Oax9TcqE+q2SYSTFTP8lpTqov24=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "1.3.4",
@@ -10717,99 +10217,160 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+          "bundled": true,
           "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.3",
+            "wrappy": "1.0.1"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.7.tgz",
-          "integrity": "sha1-deUB+dKIm6L+n+Evk2ul2tUMo1o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
             "path-is-inside": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz"
+            "rimraf": "2.5.0"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.0.5"
           }
         },
         "fstream": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "integrity": "sha1-fo16c6uzZH7zbkuKFcqAHboD0Dg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
             "inherits": "2.0.1",
             "mkdirp": "0.5.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz"
+            "rimraf": "2.5.0"
           }
         },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+        "fstream-npm": {
+          "version": "1.0.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "file:../has-unicode",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "fstream-ignore": "1.0.3",
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "fstream-ignore": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fstream": "1.0.8",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.1"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.2.1",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-          "integrity": "sha1-XwLNiVh85YsVSuCFXeAqLmOYb8o=",
+          "version": "6.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "1.0.4",
             "inherits": "2.0.1",
             "minimatch": "3.0.0",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "path-is-absolute": "1.0.0"
           },
           "dependencies": {
             "minimatch": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                "brace-expansion": "1.1.2"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                  "version": "1.1.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                    "balanced-match": "0.3.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                      "version": "0.3.0",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10818,74 +10379,66 @@
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
+          "bundled": true,
           "dev": true
         },
         "has-unicode": {
-          "version": "file:../has-unicode",
-          "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+          "version": "2.1.4",
+          "bundled": true,
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "wrappy": "1.0.1"
           }
         },
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.1.tgz",
-          "integrity": "sha1-oo4FtbrrM2PNRz32jTDTqAUjoxw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "5.0.15",
-            "npm-package-arg": "4.1.1",
+            "npm-package-arg": "4.1.0",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "read-package-json": "2.0.2",
+            "semver": "5.1.0",
             "validate-npm-package-license": "3.0.1",
             "validate-npm-package-name": "2.2.2"
           },
@@ -10899,14 +10452,13 @@
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
                 "minimatch": "3.0.4",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                "once": "1.3.3",
                 "path-is-absolute": "1.0.1"
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "read": "1.0.7"
@@ -10914,28 +10466,19 @@
             }
           }
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
-          "integrity": "sha1-ISP6DbLWnCjVvrHB821hUip0AjQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseindexof": "3.1.0",
@@ -10945,20 +10488,17 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+          "bundled": true,
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+          "bundled": true,
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
@@ -10966,14 +10506,12 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "bundled": true,
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseclone": "3.3.0",
@@ -10982,8 +10520,7 @@
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-              "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._arraycopy": "3.0.0",
@@ -10996,20 +10533,17 @@
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-                  "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._arrayeach": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-                  "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._basecopy": "3.0.1",
@@ -11018,16 +10552,14 @@
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-                  "integrity": "sha1-Okzs5bcDHq54pEHFQWuQh47u5aE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11036,20 +10568,17 @@
         },
         "lodash.isarguments": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-          "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA=",
+          "bundled": true,
           "dev": true
         },
         "lodash.isarray": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "bundled": true,
           "dev": true
         },
         "lodash.keys": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1",
@@ -11059,14 +10588,12 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "bundled": true,
           "dev": true
         },
         "lodash.union": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
-          "integrity": "sha1-pKMGb8Fdan+BUczpvf5j3Of1vP8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseflatten": "3.1.4",
@@ -11076,8 +10603,7 @@
           "dependencies": {
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.isarguments": "3.0.4",
@@ -11088,8 +10614,7 @@
         },
         "lodash.uniq": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
-          "integrity": "sha1-FGw28l510ZUBukAuiLoUk39jzYs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._basecallback": "3.3.1",
@@ -11101,8 +10626,7 @@
           "dependencies": {
             "lodash._basecallback": {
               "version": "3.3.1",
-              "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-              "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._baseisequal": "3.0.7",
@@ -11113,8 +10637,7 @@
               "dependencies": {
                 "lodash._baseisequal": {
                   "version": "3.0.7",
-                  "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-                  "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.isarray": "3.0.4",
@@ -11124,16 +10647,14 @@
                   "dependencies": {
                     "lodash.istypedarray": {
                       "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
-                      "integrity": "sha1-k5exE8FfQk8yCvBsqlnMSV4gk84=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "lodash.pairs": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-                  "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.keys": "3.1.2"
@@ -11143,16 +10664,14 @@
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash.without": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-3.2.1.tgz",
-          "integrity": "sha1-1pYUs1EuUilLarq3gufKllOM6BY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._basedifference": "3.0.3",
@@ -11161,8 +10680,7 @@
           "dependencies": {
             "lodash._basedifference": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-              "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._baseindexof": "3.1.0",
@@ -11174,8 +10692,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -11183,71 +10700,68 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "node-gyp": {
-          "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
-          "integrity": "sha1-9d1WmXClCEZMw8Fdfp6NLehjjdU=",
+          "version": "3.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream": "1.0.8",
             "glob": "4.5.3",
             "graceful-fs": "4.1.2",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+            "minimatch": "1.0.0",
             "mkdirp": "0.5.1",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "nopt": "3.0.6",
             "npmlog": "1.2.1",
             "osenv": "0.1.3",
             "path-array": "1.0.0",
-            "request": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "request": "2.67.0",
+            "rimraf": "2.5.0",
+            "semver": "5.1.0",
             "tar": "2.2.1",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.1.tgz"
+            "which": "1.2.1"
           },
           "dependencies": {
             "glob": {
               "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
                 "minimatch": "2.0.10",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                "once": "1.3.3"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                    "brace-expansion": "1.1.2"
                   },
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "version": "1.1.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "version": "0.3.0",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
-                          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11263,30 +10777,29 @@
               "dev": true
             },
             "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "version": "2.7.3",
+                  "bundled": true,
                   "dev": true
                 },
                 "sigmund": {
-                  "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "version": "1.0.1",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "npmlog": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-              "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "0.3.0",
@@ -11296,14 +10809,12 @@
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
-                  "integrity": "sha1-dLLx8YfIVTx/lQFby3YAn7Q9OOA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                  "integrity": "sha1-Un/jife8upCAYQa5kkTqoH6Ib4U=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "0.1.0",
@@ -11312,35 +10823,33 @@
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
-                      "integrity": "sha1-tLV74RoWU1F6BLJ/CUm9wyff45A=",
+                      "bundled": true,
                       "dev": true
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "core-util-is": "1.0.2",
                         "inherits": "2.0.1",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
                       },
                       "dependencies": {
                         "core-util-is": {
-                          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "version": "1.0.2",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
-                          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
-                          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "version": "0.10.31",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11349,8 +10858,7 @@
                 },
                 "gauge": {
                   "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                  "integrity": "sha1-BbZzChmo/K08NAoULwlFIio/gVs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi": "0.3.0",
@@ -11362,8 +10870,7 @@
                   "dependencies": {
                     "lodash.pad": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                      "integrity": "sha1-LgeOvDOzMdK6NL+HMq8Sn9XARiQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11372,14 +10879,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11387,8 +10892,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11400,8 +10904,7 @@
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                      "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11410,14 +10913,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11425,8 +10926,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11438,8 +10938,7 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                      "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11448,14 +10947,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11463,8 +10960,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11480,8 +10976,7 @@
             },
             "path-array": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
-              "integrity": "sha1-bBQTDDMITwFQVTxlezg5erZ6qk4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "array-index": "0.1.1"
@@ -11489,24 +10984,23 @@
               "dependencies": {
                 "array-index": {
                   "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
-                  "integrity": "sha1-TV6vBsw9klhHzXPRU1whe6MG0+E=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                    "debug": "2.2.0"
                   },
                   "dependencies": {
                     "debug": {
-                      "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                      "version": "2.2.0",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        "ms": "0.7.1"
                       },
                       "dependencies": {
                         "ms": {
-                          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                          "version": "0.7.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11518,8 +11012,8 @@
           }
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "3.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1.0.7"
@@ -11527,26 +11021,23 @@
         },
         "normalize-git-url": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.1.tgz",
-          "integrity": "sha1-1A1BnQWhWHAnHlBTTbt7jM2bClw=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
+            "hosted-git-info": "2.1.4",
             "is-builtin-module": "1.0.0",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "validate-npm-package-license": "3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "builtin-modules": "1.1.0"
@@ -11554,8 +11045,7 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                  "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11564,18 +11054,16 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-2.0.1.tgz",
-          "integrity": "sha1-qTVAtT8E+p2RbScz1lQfbbfYjkY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "npmlog": "1.2.1",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+            "semver": "5.1.0"
           },
           "dependencies": {
             "has-unicode": {
@@ -11586,8 +11074,7 @@
             },
             "npmlog": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-              "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "0.3.0",
@@ -11597,14 +11084,12 @@
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
-                  "integrity": "sha1-dLLx8YfIVTx/lQFby3YAn7Q9OOA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                  "integrity": "sha1-Un/jife8upCAYQa5kkTqoH6Ib4U=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "0.1.0",
@@ -11613,14 +11098,12 @@
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
-                      "integrity": "sha1-tLV74RoWU1F6BLJ/CUm9wyff45A=",
+                      "bundled": true,
                       "dev": true
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "core-util-is": "1.0.1",
@@ -11631,20 +11114,17 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11653,8 +11133,7 @@
                 },
                 "gauge": {
                   "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                  "integrity": "sha1-BbZzChmo/K08NAoULwlFIio/gVs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi": "0.3.0",
@@ -11666,8 +11145,7 @@
                   "dependencies": {
                     "lodash.pad": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                      "integrity": "sha1-LgeOvDOzMdK6NL+HMq8Sn9XARiQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11676,14 +11154,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11691,8 +11167,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11704,8 +11179,7 @@
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                      "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11714,14 +11188,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11729,8 +11201,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11742,8 +11213,7 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                      "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11752,14 +11222,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11767,8 +11235,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11785,35 +11252,244 @@
           }
         },
         "npm-package-arg": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.1.tgz",
-          "integrity": "sha1-htncqYW0xeXVl3Lf1d5pGZmKSVo=",
+          "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+            "hosted-git-info": "2.1.4",
+            "semver": "5.1.0"
+          }
+        },
+        "npm-registry-client": {
+          "version": "7.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "concat-stream": "1.5.1",
+            "graceful-fs": "4.1.2",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.3.5",
+            "npm-package-arg": "4.1.0",
+            "npmlog": "2.0.0",
+            "once": "1.3.3",
+            "request": "2.67.0",
+            "retry": "0.8.0",
+            "rimraf": "2.5.0",
+            "semver": "5.1.0",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "readable-stream": "2.0.5",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "npm-user-validate": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz",
-          "integrity": "sha1-1YXaC0fJ9BqebKaEtv2EukHr6H0=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
+            "ansi": "0.3.0",
+            "are-we-there-yet": "1.0.4",
+            "gauge": "1.2.2"
+          },
+          "dependencies": {
+            "ansi": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "0.1.0",
+                "readable-stream": "1.1.13"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "gauge": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi": "0.3.0",
+                "has-unicode": "1.0.1",
+                "lodash.pad": "3.1.1",
+                "lodash.padleft": "3.1.1",
+                "lodash.padright": "3.1.1"
+              },
+              "dependencies": {
+                "lodash.pad": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.padleft": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "has-unicode": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+              "integrity": "sha1-xG/O6gU+uOx4m/+7ol/KUt/c844=",
+              "dev": true
+            }
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "version": "1.3.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.1"
@@ -11821,14 +11497,12 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "1.0.1",
@@ -11837,28 +11511,24 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+              "bundled": true,
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
+          "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "0.0.5"
@@ -11866,16 +11536,14 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2"
@@ -11883,80 +11551,141 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.2",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.2",
             "readdir-scoped-modules": "1.0.2",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "slide": "1.1.6",
             "util-extend": "1.0.1"
           },
           "dependencies": {
             "util-extend": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
-              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
+              "bundled": true,
               "dev": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "graceful-fs": "4.1.2",
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.3.5"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.4",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "json-parse-helpfulerror": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jju": "1.2.1"
+              },
+              "dependencies": {
+                "jju": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.2.tgz",
-          "integrity": "sha1-46SIeS9Az0cIGfAaYQ5xnWTwkJQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "read-package-json": "2.0.12",
+            "once": "1.3.3",
+            "read-package-json": "2.0.2",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+          "version": "2.0.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+            "process-nextick-args": "1.0.6",
             "string_decoder": "0.10.31",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "process-nextick-args": {
-              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
               "dev": true
             },
             "util-deprecate": {
-              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "graceful-fs": "4.1.2",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+            "once": "1.3.3"
+          }
+        },
+        "realize-package-specifier": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3",
+            "npm-package-arg": "4.1.0"
           }
         },
         "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+          "version": "2.67.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
@@ -11966,46 +11695,42 @@
             "extend": "3.0.0",
             "forever-agent": "0.6.1",
             "form-data": "1.0.0-rc3",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "har-validator": "2.0.3",
+            "hawk": "3.1.2",
+            "http-signature": "1.1.0",
+            "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "mime-types": "2.1.8",
+            "node-uuid": "1.4.7",
             "oauth-sign": "0.8.0",
             "qs": "5.2.0",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
           },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true
             },
             "bl": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                "readable-stream": "2.0.5"
               }
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -12013,57 +11738,52 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                "async": "1.5.0",
                 "combined-stream": "1.0.5",
-                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
+                "mime-types": "2.1.8"
               },
               "dependencies": {
                 "async": {
-                  "version": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-                  "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
+                  "version": "1.5.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-              "integrity": "sha1-Wp4SVkpXHPC4Hvk8IVe9FhcWiIM=",
+              "version": "2.0.3",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "1.1.1",
                 "commander": "2.9.0",
-                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                "is-my-json-valid": "2.12.3",
+                "pinkie-promise": "2.0.0"
               },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-styles": "2.1.0",
@@ -12075,20 +11795,17 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.0.0"
@@ -12096,16 +11813,14 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-readlink": "1.0.1"
@@ -12113,33 +11828,30 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                  "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
+                  "version": "2.12.3",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "generate-function": "2.0.0",
                     "generate-object-property": "1.2.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-property": "1.0.2"
@@ -12147,36 +11859,34 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "xtend": {
-                      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "version": "4.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
-                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "version": "2.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    "pinkie": "2.0.1"
                   },
                   "dependencies": {
                     "pinkie": {
-                      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                      "version": "2.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -12184,19 +11894,19 @@
               }
             },
             "hawk": {
-              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "integrity": "sha1-kMkBGIhuIZddGtSumz4oTtGaLeg=",
+              "version": "3.1.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "boom": "2.10.1",
                 "cryptiles": "2.0.5",
                 "hoek": "2.16.3",
                 "sntp": "1.0.9"
               },
               "dependencies": {
                 "boom": {
-                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "version": "2.10.1",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -12204,23 +11914,20 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    "boom": "2.10.1"
                   }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -12229,78 +11936,77 @@
               }
             },
             "http-signature": {
-              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "integrity": "sha1-XS1+m270mYCtWxKNjk7wmjHJDZU=",
+              "version": "1.1.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "assert-plus": "0.1.5",
-                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz"
+                "jsprim": "1.2.2",
+                "sshpk": "1.7.1"
               },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "jsprim": {
-                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "version": "1.2.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
                   },
                   "dependencies": {
                     "extsprintf": {
-                      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "json-schema": {
-                      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "version": "0.2.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "verror": {
-                      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "version": "1.3.6",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        "extsprintf": "1.0.2"
                       }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "integrity": "sha1-Vl44bEKnfmBi+9FMBHL/Ic1TOYw=",
+                  "version": "1.7.1",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    "asn1": "0.2.3",
+                    "assert-plus": "0.2.0",
+                    "dashdash": "1.10.1",
+                    "ecc-jsbn": "0.1.1",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.2"
                   },
                   "dependencies": {
                     "asn1": {
-                      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "version": "0.2.3",
+                      "bundled": true,
                       "dev": true
                     },
                     "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "version": "0.2.0",
+                      "bundled": true,
                       "dev": true
                     },
                     "dashdash": {
-                      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "integrity": "sha1-Cr8a+JqPUSmoHxjCs1sh3yJiL2A=",
+                      "version": "1.10.1",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "assert-plus": "0.1.5"
@@ -12308,39 +12014,38 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "ecc-jsbn": {
-                      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "version": "0.1.1",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jodid25519": {
-                      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jsbn": {
-                      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "version": "0.1.0",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
-                      "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ=",
+                      "version": "0.13.2",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -12349,122 +12054,117 @@
               }
             },
             "is-typedarray": {
-              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
-              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "integrity": "sha1-+vV4I94EvHy/9O6CxrY5RugSrnI=",
+              "version": "2.1.8",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                "mime-db": "1.20.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-                  "integrity": "sha1-SW+Q/QH+DgMciCPsOqlFD/2hjtg=",
+                  "version": "1.20.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-uuid": {
-              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "version": "1.4.7",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+              "bundled": true,
               "dev": true
             },
             "qs": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+              "bundled": true,
               "dev": true
             },
             "stringstream": {
-              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "version": "0.0.5",
+              "bundled": true,
               "dev": true
             },
             "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "version": "2.2.1",
+              "bundled": true,
               "dev": true
             },
             "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "version": "0.4.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "retry": {
           "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
-          "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-          "integrity": "sha1-MMCWzfdy4mvz4dLP+EwhllQam7Y=",
+          "version": "2.5.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz"
+            "glob": "6.0.3"
           },
           "dependencies": {
             "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-              "integrity": "sha1-XwLNiVh85YsVSuCFXeAqLmOYb8o=",
+              "version": "6.0.3",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
               },
               "dependencies": {
                 "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                  "version": "3.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                    "brace-expansion": "1.1.2"
                   },
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "version": "1.1.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "version": "0.3.0",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
-                          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -12472,8 +12172,8 @@
                   }
                 },
                 "path-is-absolute": {
-                  "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "version": "1.0.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -12481,36 +12181,32 @@
           }
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "version": "5.1.0",
+          "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+            "readable-stream": "2.0.5"
           }
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "sorted-object": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
-          "integrity": "sha1-XR9PnB+yzUiWWWcwTiEutEz7bQU=",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.0.0"
@@ -12518,8 +12214,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.8",
@@ -12529,8 +12224,7 @@
           "dependencies": {
             "block-stream": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-              "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "2.0.1"
@@ -12540,40 +12234,45 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "unique-filename": {
-          "version": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.1",
@@ -12582,8 +12281,7 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
-              "integrity": "sha1-rAdfXy9qBsC/3RyEfrPd492CIeo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-license-ids": "1.0.2"
@@ -12591,8 +12289,7 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
-              "integrity": "sha1-T7t+c4yemPoLCRTf2WGsZin7ze8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-exceptions": "1.0.3",
@@ -12601,24 +12298,21 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
-                  "integrity": "sha1-Oexe0s693wjRgFVdfpnDr/m0dko=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "spdx-license-ids": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-              "integrity": "sha1-BnTpyaIw+YABa1sHOhCqFlcBZ3w=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -12626,15 +12320,14 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
-          "integrity": "sha1-oBDEOq3hp5ij5sGx5FPUXLSXorw=",
+          "version": "1.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-absolute": "0.1.7"
@@ -12642,8 +12335,7 @@
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-relative": "0.1.3"
@@ -12651,8 +12343,7 @@
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -12661,18 +12352,16 @@
         },
         "wrappy": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
         }
@@ -12686,55 +12375,6 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "semver": "5.4.1"
-      }
-    },
-    "npm-registry-client": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.0.9.tgz",
-      "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
-      "dev": true,
-      "requires": {
-        "chownr": "1.0.1",
-        "concat-stream": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "4.2.1",
-        "npmlog": "2.0.4",
-        "once": "1.4.0",
-        "request": "2.81.0",
-        "retry": "0.8.0",
-        "rimraf": "2.6.1",
-        "semver": "5.4.1",
-        "slide": "1.1.6"
-      },
-      "dependencies": {
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        },
-        "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
-          }
-        }
       }
     },
     "npm-run-path": {
@@ -12840,23 +12480,12 @@
       }
     },
     "object-visit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-      "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
+        "isobject": "3.0.1"
       }
     },
     "object.omit": {
@@ -13137,9 +12766,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "pascalcase": {
@@ -13205,9 +12834,9 @@
       "dev": true
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "phantomjs-prebuilt": {
@@ -13227,11 +12856,62 @@
         "which": "1.2.14"
       },
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
         "es6-promise": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
           "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
           "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
         },
         "fs-extra": {
           "version": "1.0.0",
@@ -13244,11 +12924,107 @@
             "klaw": "1.3.1"
           }
         },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true
+        },
         "progress": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "which": {
           "version": "1.2.14",
@@ -13292,9 +13068,9 @@
       }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "pn": {
@@ -13432,13 +13208,6 @@
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
       "requires": {
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "proxy-addr": {
@@ -13447,7 +13216,7 @@
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.0",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.4.0"
       }
     },
@@ -13481,7 +13250,7 @@
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
       "requires": {
         "mktemp": "0.4.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "underscore.string": "3.3.4"
       }
     },
@@ -13688,7 +13457,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -13701,6 +13470,17 @@
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
       }
     },
     "range-parser": {
@@ -13732,19 +13512,6 @@
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
       "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=",
       "dev": true
-    },
-    "read-package-json": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
-      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.1",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
-      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -13846,16 +13613,6 @@
         }
       }
     },
-    "realize-package-specifier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
-      "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3",
-        "npm-package-arg": "4.2.1"
-      }
-    },
     "recast": {
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.6.tgz",
@@ -13897,9 +13654,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator": {
       "version": "0.8.40",
@@ -13982,7 +13739,7 @@
       "requires": {
         "esprima": "2.7.3",
         "recast": "0.10.43",
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       },
@@ -14026,7 +13783,7 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -14077,39 +13834,51 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
+      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
+        "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.5",
-        "extend": "3.0.0",
+        "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.0.1"
+        "uuid": "3.1.0"
       },
       "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
+        },
         "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
@@ -14243,12 +14012,6 @@
         "onetime": "1.1.0"
       }
     },
-    "retry": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
-      "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
-      "dev": true
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -14259,17 +14022,17 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
     },
     "rollbar": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.2.7.tgz",
-      "integrity": "sha512-5D4GtIinI36ETbyTIgWqB8IW3U2KqoKDfeRwGn2eJnOkPYSCxgtIFMTS3WNndAI0qrBAZiuw7x5wLpbVoIKZtQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.2.8.tgz",
+      "integrity": "sha512-zdghZXyC0Hr9qy3xAFyBlAwTzgcbbhu+DgSEeppwZ0EM354excq0jTdsdLHegoQzbKUNOl08F5afJ7KJ2mrEvw==",
       "requires": {
         "async": "1.2.1",
         "console-polyfill": "0.3.0",
@@ -14291,10 +14054,9 @@
       }
     },
     "rsvp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.0.1.tgz",
-      "integrity": "sha512-EzazW+1W0MqpfPBhApGcKU2xbEuzgs+rO4FvcvuRN1OtLxNFgf9Ce31WGXwGk4VyQQzU8hNyRLjHMzJt+D0STw==",
-      "dev": true
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -14345,7 +14107,7 @@
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
@@ -14425,7 +14187,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
+        "js-base64": "2.3.2",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -14456,7 +14218,7 @@
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
+        "etag": "1.8.1",
         "fresh": "0.5.0",
         "http-errors": "1.6.2",
         "mime": "1.3.4",
@@ -14482,7 +14244,7 @@
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "send": "0.15.4"
       }
     },
@@ -14508,15 +14270,26 @@
       "dev": true
     },
     "set-value": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-      "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
         "is-plain-object": "2.0.4",
-        "to-object-path": "0.3.0"
+        "split-string": "3.0.2"
+      },
+      "dependencies": {
+        "split-string": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
+          "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1"
+          }
+        }
       }
     },
     "setprototypeof": {
@@ -14596,19 +14369,13 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "0.11.1",
+        "base": "0.11.2",
         "debug": "2.6.8",
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
@@ -14637,12 +14404,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -14678,12 +14439,12 @@
       }
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "socket.io": {
@@ -14861,9 +14622,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
-      "integrity": "sha512-30c1Ch8FSjV0FwC253iftbbj0dU/OXoSg1LAEGZJUlGgjTNj6cu+DVqJWWIZJY5RXLWV4eFtR+4ouo0VIOYOTg==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -14995,14 +14756,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "stable": {
@@ -15045,12 +14798,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -15326,7 +15073,7 @@
       "dev": true,
       "requires": {
         "events-to-array": "1.1.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "readable-stream": "2.3.3"
       },
       "dependencies": {
@@ -15403,7 +15150,7 @@
         "fireworm": "0.7.1",
         "glob": "7.1.2",
         "http-proxy": "1.16.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash.assignin": "4.2.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.find": "4.6.0",
@@ -15413,7 +15160,7 @@
         "node-notifier": "5.1.2",
         "npmlog": "4.1.2",
         "printf": "0.2.5",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "socket.io": "1.6.0",
         "spawn-args": "0.2.0",
         "styled_string": "0.0.1",
@@ -15596,12 +15343,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -15648,7 +15389,7 @@
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -15775,24 +15516,29 @@
       }
     },
     "union-value": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-      "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
         "arr-union": "3.1.0",
         "get-value": "2.0.6",
         "is-extendable": "0.1.1",
         "set-value": "0.4.3"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "0.1.4"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
       }
     },
     "unique-string": {
@@ -15817,13 +15563,43 @@
       "dev": true
     },
     "unset-value": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-      "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
         "has-value": "0.3.1",
         "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
       }
     },
     "untildify": {
@@ -15880,12 +15656,6 @@
             "is-data-descriptor": "0.1.4",
             "kind-of": "5.0.2"
           }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
         }
       }
     },
@@ -15950,14 +15720,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "vinyl": {
@@ -15985,7 +15747,7 @@
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "requires": {
         "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.4"
+        "matcher-collection": "1.0.5"
       }
     },
     "walker": {
@@ -16004,18 +15766,19 @@
       "dev": true
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "websocket-extensions": "0.1.1"
+        "http-parser-js": "0.4.6",
+        "websocket-extensions": "0.1.2"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
       "dev": true
     },
     "which": {
@@ -16203,7 +15966,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "broccoli-funnel": "2.0.1",
     "ember-cli-babel": "6.8.2",
-    "rollbar": "~2.2.7"
+    "rollbar": "~2.2.8"
   },
   "devDependencies": {
     "bootstrap-sass": "3.3.7",
@@ -50,7 +50,6 @@
     "ember-load-initializers": "1.0.0",
     "ember-resolver": "4.5.0",
     "ember-scroll-to": "0.6.4",
-    "ember-source": "~2.15.0",
     "loader.js": "4.6.0"
   },
   "engines": {

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -95,4 +95,27 @@ test('registerLogger: does not register logger if disabled', function(assert) {
   };
   service.registerLogger();
   Ember.onerror();
+});
+
+test('config: rollbar passes arguments to checkIgnore callback', function (assert) {
+  assert.expect(3);
+
+  let service = this.subject({
+    config: {
+      enabled: true,
+      checkIgnore: function(isUnchaught, args, payload) {
+        assert.equal(false, isUnchaught);
+        assert.deepEqual(args[0], {
+          msg: 'error',
+          code: 1
+        });
+        assert.ok(payload);
+        return true;
+      }
+    }
+  });
+  service.error({
+    msg: 'error',
+    code: 1
+  });
 })


### PR DESCRIPTION
I also added a test to verifiy that `checkIgnore` works correctly. 
It is probably not necessary for a simple update but it does verify that the callback works correctly after the version bump and fails before that.