### PR TITLE
The application code version as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can overwrite Rollbar configuration in environment's config. Here is the def
         source_map_enabled: true,
         guess_uncaught_frames: true
         // code_version: "some version string, such as a version number or git sha",
+        // leave empty to use application version which is a default value
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can overwrite Rollbar configuration in environment's config. Here is the def
       javascript: {
         source_map_enabled: true,
         guess_uncaught_frames: true
-        // code_version: "some version string, such as a version number or git sha",
+        code_version: "YOUR_APP_VERSION" // returns app version in format: 2.4.0+06df23a
         // leave empty to use application version which is a default value
       }
     }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ You can use `rollbarClient` function of the `Rollbar Service` to create a new in
 this.get('rollbar').rollbarClient(/* config */)
 ```
 
+### Support code_version on Heroku build
+Add at the bottom of your `config/environment.js` file:
+```js
+// Heroku Git Hash support
+if (process.env.SOURCE_VERSION) {
+  let packageJson = require('../package.json');
+  let gitHash = process.env.SOURCE_VERSION.substr(0, 7);
+  ENV.emberRollbarClient.payload.client.javascript['code_version'] = `${packageJson.version}+${gitHash}`;
+}
+```
+
 ## Configuration
 You can overwrite Rollbar configuration in environment's config. Here is the default config:
 

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -15,7 +15,7 @@ export default Ember.Service.extend({
   }),
 
   rollbarClient(customConfig = {}) {
-    let config = deepMerge(this.get('config'), customConfig);
+    let config = deepMerge({}, this.get('config'), customConfig);
     return new Rollbar(config);
   },
 

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -10,11 +10,14 @@ export default Ember.Service.extend({
   }),
 
   config: Ember.computed(function() {
-    return Ember.getOwner(this).resolveRegistration('config:environment').emberRollbarClient;
+    const applicationConfig = Ember.getOwner(this).resolveRegistration('config:environment');
+    const code_version = applicationConfig.APP.version;
+    const userConfig = applicationConfig.emberRollbarClient;
+    return Ember.assign({ code_version }, userConfig);
   }),
 
   rollbarClient(customConfig = {}) {
-    let config = Ember.assign(this.get('config'), customConfig);
+    const config = Ember.assign(this.get('config'), customConfig);
     return new Rollbar(config);
   },
 

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Rollbar from 'rollbar';
+import deepMerge from 'lodash/merge';
 
 export default Ember.Service.extend({
   currentUser: null,
@@ -20,7 +21,7 @@ export default Ember.Service.extend({
   }),
 
   rollbarClient(customConfig = {}) {
-    let config = Ember.assign(this.get('config'), customConfig);
+    let config = deepMerge(this.get('config'), customConfig);
     return new Rollbar(config);
   },
 

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -10,9 +10,9 @@ export default Ember.Service.extend({
   }),
 
   config: Ember.computed(function() {
-    const applicationConfig = Ember.getOwner(this).resolveRegistration('config:environment');
-    const code_version = applicationConfig.APP.version;
-    const userConfig = applicationConfig.emberRollbarClient;
+    let applicationConfig = Ember.getOwner(this).resolveRegistration('config:environment');
+    let code_version = applicationConfig.APP.version;
+    let userConfig = applicationConfig.emberRollbarClient;
     if ( !userConfig.payload.client.javascript.code_version ) {
       userConfig.payload.client.javascript.code_version = code_version;
     }
@@ -20,7 +20,7 @@ export default Ember.Service.extend({
   }),
 
   rollbarClient(customConfig = {}) {
-    const config = Ember.assign(this.get('config'), customConfig);
+    let config = Ember.assign(this.get('config'), customConfig);
     return new Rollbar(config);
   },
 

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -13,7 +13,10 @@ export default Ember.Service.extend({
     const applicationConfig = Ember.getOwner(this).resolveRegistration('config:environment');
     const code_version = applicationConfig.APP.version;
     const userConfig = applicationConfig.emberRollbarClient;
-    return Ember.assign({ code_version }, userConfig);
+    if ( !userConfig.payload.client.javascript.code_version ) {
+      userConfig.payload.client.javascript.code_version = code_version;
+    }
+    return userConfig;
   }),
 
   rollbarClient(customConfig = {}) {

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -11,13 +11,7 @@ export default Ember.Service.extend({
   }),
 
   config: Ember.computed(function() {
-    let applicationConfig = Ember.getOwner(this).resolveRegistration('config:environment');
-    let code_version = applicationConfig.APP.version;
-    let userConfig = applicationConfig.emberRollbarClient;
-    if ( !userConfig.payload.client.javascript.code_version ) {
-      userConfig.payload.client.javascript.code_version = code_version;
-    }
-    return userConfig;
+    return Ember.getOwner(this).resolveRegistration('config:environment').emberRollbarClient;
   }),
 
   rollbarClient(customConfig = {}) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,17 +2,8 @@
 'use strict';
 
 function codeVersion() {
-  // Heroku Git Hash support
-  if (process.env.SOURCE_VERSION) {
-    let packageJson = require('../package.json');
-    let gitHash = process.env.SOURCE_VERSION.substr(0, 7);
-
-    return `${packageJson.version}+${gitHash}`;
-  } else {
-    let gitRepoVersion = require('git-repo-version');
-
-    return gitRepoVersion({ shaLength: 7 });
-  }
+  let gitRepoVersion = require('git-repo-version');
+  return gitRepoVersion({ shaLength: 7 });
 }
 
 module.exports = function(environment, appConfig) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,20 @@
 /* eslint-env node */
 'use strict';
 
+function codeVersion() {
+  // Heroku Git Hash support
+  if (process.env.SOURCE_VERSION) {
+    let packageJson = require('../package.json');
+    let gitHash = process.env.SOURCE_VERSION.substr(0, 7);
+
+    return `${packageJson.version}+${gitHash}`;
+  } else {
+    let gitRepoVersion = require('git-repo-version');
+
+    return gitRepoVersion({ shaLength: 7 });
+  }
+}
+
 module.exports = function(environment, appConfig) {
   appConfig.emberRollbarClient = {
     enabled: environment !== 'test' && environment !== 'development',
@@ -13,7 +27,7 @@ module.exports = function(environment, appConfig) {
       client: {
         javascript: {
           source_map_enabled: true,
-          // code_version: "some version string, such as a version number or git sha",
+          code_version: codeVersion(), // returns app version in format: 2.4.0+06df23a
           // Optionally have Rollbar guess which frames the error was thrown from
           // when the browser does not provide line and column numbers.
           guess_uncaught_frames: true

--- a/config/release.js
+++ b/config/release.js
@@ -1,4 +1,4 @@
-/* jshint node:true */
+/* eslint-env node */
 // var RSVP = require('rsvp');
 
 // For details on each option run `ember help release`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-rollbar-client",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,64 +33,64 @@
       }
     },
     "@glimmer/node": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.25.3.tgz",
-      "integrity": "sha1-MBgo6EVb4UHVOEsBmA7ZvgKYQFk=",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.25.6.tgz",
+      "integrity": "sha512-nAZmAm7kxJlUHH525WnmG84iOYgUVt6PfsbE0Nmy1McgAb3g2HHRWlrXSzbGzkl+J672aeGGfcbKn8Y6BVDanQ==",
       "dev": true,
       "requires": {
-        "@glimmer/runtime": "0.25.3",
+        "@glimmer/runtime": "0.25.6",
         "simple-dom": "0.3.2"
       }
     },
     "@glimmer/object": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/object/-/object-0.25.3.tgz",
-      "integrity": "sha1-RR6yCNrboe3pwMA4qQ3+MmN0k/4=",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/object/-/object-0.25.6.tgz",
+      "integrity": "sha512-lX5dHjX7fNKVObNotD1hlJZixIUi39rTZlHIJiXCkp4Om7diRBAsN9T9TdNTqCqC7SjlsnPuNvGc9mKviCmiYg==",
       "dev": true,
       "requires": {
-        "@glimmer/object-reference": "0.25.3",
-        "@glimmer/util": "0.25.3"
+        "@glimmer/object-reference": "0.25.6",
+        "@glimmer/util": "0.25.6"
       },
       "dependencies": {
         "@glimmer/util": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
-          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.6.tgz",
+          "integrity": "sha512-Ip1qpA5WWuTRUb/pecI85aVmOwA8ZBVQKwEml4P56Ia8X6yEp0wtqnER02L9gKTzaeUXjsJnoW90upSLTxy6GQ==",
           "dev": true
         }
       }
     },
     "@glimmer/object-reference": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/object-reference/-/object-reference-0.25.3.tgz",
-      "integrity": "sha1-4NH6h0+RLn0SMtSH/NIJbmsxtiA=",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/object-reference/-/object-reference-0.25.6.tgz",
+      "integrity": "sha512-T8ncWEiQe/AQhzuOSKwIWTmSicLFZJLtCQbcIXx942OYVf69NBaTP0FYz+nfHT3dfUicLV7Hhsz/jDxwq4IJBw==",
       "dev": true,
       "requires": {
-        "@glimmer/reference": "0.25.3",
-        "@glimmer/util": "0.25.3"
+        "@glimmer/reference": "0.25.6",
+        "@glimmer/util": "0.25.6"
       },
       "dependencies": {
         "@glimmer/util": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
-          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.6.tgz",
+          "integrity": "sha512-Ip1qpA5WWuTRUb/pecI85aVmOwA8ZBVQKwEml4P56Ia8X6yEp0wtqnER02L9gKTzaeUXjsJnoW90upSLTxy6GQ==",
           "dev": true
         }
       }
     },
     "@glimmer/reference": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.25.3.tgz",
-      "integrity": "sha1-oJ3cOXvuAiPec+pQRKMEowk1EE8=",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.25.6.tgz",
+      "integrity": "sha512-/sYLfQ2hRtREpzxlB71tuy3cW1SJDYfOcvwEmBG17uaLkOtYAQaqn6h+vQrQBl94ugCYFTvK0TFiK/nJ1WOu1A==",
       "dev": true,
       "requires": {
-        "@glimmer/util": "0.25.3"
+        "@glimmer/util": "0.25.6"
       },
       "dependencies": {
         "@glimmer/util": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
-          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.6.tgz",
+          "integrity": "sha512-Ip1qpA5WWuTRUb/pecI85aVmOwA8ZBVQKwEml4P56Ia8X6yEp0wtqnER02L9gKTzaeUXjsJnoW90upSLTxy6GQ==",
           "dev": true
         }
       }
@@ -105,41 +105,41 @@
       }
     },
     "@glimmer/runtime": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.25.3.tgz",
-      "integrity": "sha1-riEBoeTeMzDQjyCAbBgyfb+obXg=",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.25.6.tgz",
+      "integrity": "sha512-geUWcOZlPzIxAovT/AyD3T31A1JR4vKZthD8p8DOxX3lVekW79OL/7e8OF7sCrCgiSx9ctoM/KDDFPU7qE7uXg==",
       "dev": true,
       "requires": {
-        "@glimmer/interfaces": "0.25.3",
-        "@glimmer/object": "0.25.3",
-        "@glimmer/object-reference": "0.25.3",
-        "@glimmer/reference": "0.25.3",
-        "@glimmer/util": "0.25.3",
-        "@glimmer/wire-format": "0.25.3"
+        "@glimmer/interfaces": "0.25.6",
+        "@glimmer/object": "0.25.6",
+        "@glimmer/object-reference": "0.25.6",
+        "@glimmer/reference": "0.25.6",
+        "@glimmer/util": "0.25.6",
+        "@glimmer/wire-format": "0.25.6"
       },
       "dependencies": {
         "@glimmer/interfaces": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.25.3.tgz",
-          "integrity": "sha1-jEYLKK1aF+qhcS5qp7jrtJc4w48=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.25.6.tgz",
+          "integrity": "sha512-upd9kjJMlKvbz76hvC28mbF4tFXSR5vsjVJLXkk404EvNXVCOgIaKepMfy2SGGSWCiHai1uVIbT0YWNidIieAg==",
           "dev": true,
           "requires": {
-            "@glimmer/wire-format": "0.25.3"
+            "@glimmer/wire-format": "0.25.6"
           }
         },
         "@glimmer/util": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
-          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.6.tgz",
+          "integrity": "sha512-Ip1qpA5WWuTRUb/pecI85aVmOwA8ZBVQKwEml4P56Ia8X6yEp0wtqnER02L9gKTzaeUXjsJnoW90upSLTxy6GQ==",
           "dev": true
         },
         "@glimmer/wire-format": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.25.3.tgz",
-          "integrity": "sha1-BGaSs6JqMKSYcSJmzQvbR9dxDzc=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.25.6.tgz",
+          "integrity": "sha512-b8P7TGt2Hv90O+B8eJ1h7FtoMUtQpaAJMdwXiIK6D8xh+HGpi4jgG/HHUazo37a4B5eTaJPy7R/dz7ugF3blVQ==",
           "dev": true,
           "requires": {
-            "@glimmer/util": "0.25.3"
+            "@glimmer/util": "0.25.6"
           }
         }
       }
@@ -152,7 +152,7 @@
       "requires": {
         "@glimmer/interfaces": "0.27.0",
         "@glimmer/util": "0.27.0",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "simple-html-tokenizer": "0.3.0"
       }
     },
@@ -172,9 +172,9 @@
       }
     },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -188,9 +188,9 @@
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -217,21 +217,21 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
@@ -251,7 +251,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -277,12 +277,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "dev": true
     },
     "ansi-escapes": {
@@ -382,7 +376,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -432,7 +426,7 @@
       "dev": true,
       "requires": {
         "cson-parser": "1.3.5",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash": "3.10.1"
       },
       "dependencies": {
@@ -445,9 +439,9 @@
       }
     },
     "aproba": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -586,12 +580,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -599,9 +587,9 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "ast-traverse": {
@@ -611,38 +599,31 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.11.tgz",
-      "integrity": "sha1-NxF3u1kjL/XOqh0J7lytcFsaWqk=",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "4.17.4"
       }
     },
     "async-disk-cache": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.2.tgz",
-      "integrity": "sha1-rFPWFShD3yAslAbijXdDYmCNdN0=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
+      "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "heimdalljs": "0.2.5",
         "istextorbinary": "2.1.0",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "username-sync": "1.0.1"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "async-each": {
@@ -662,17 +643,8 @@
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
       "requires": {
-        "async": "2.5.0",
-        "debug": "2.6.8"
-      }
-    },
-    "async-some": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
-      "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3"
+        "async": "2.6.0",
+        "debug": "2.6.9"
       }
     },
     "asynckit": {
@@ -688,9 +660,9 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
@@ -725,12 +697,12 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
       }
@@ -919,11 +891,11 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz",
-      "integrity": "sha1-uq8m3Ovi7R3hIAIbxCvin1IEl7M=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.2.1.tgz",
+      "integrity": "sha1-5j+QzDxxzGs7aftRtPYDEtbPc0w=",
       "requires": {
-        "ember-rfc176-data": "0.2.7"
+        "ember-rfc176-data": "0.3.1"
       }
     },
     "babel-plugin-eval": {
@@ -1306,9 +1278,9 @@
       }
     },
     "babel-preset-env": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1337,7 +1309,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.4.0",
+        "browserslist": "2.9.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1353,7 +1325,7 @@
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.17"
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1387,7 +1359,7 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
@@ -1430,57 +1402,18 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
-      "integrity": "sha1-s2p/ERE4U6NCoVaR2Y4tzIpswnA=",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "cache-base": "0.8.5",
+        "cache-base": "1.0.1",
         "class-utils": "0.3.5",
         "component-emitter": "1.2.1",
-        "define-property": "0.2.5",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
         "mixin-deep": "1.2.0",
         "pascalcase": "0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
-        }
       }
     },
     "base64-arraybuffer": {
@@ -1496,10 +1429,13 @@
       "dev": true
     },
     "basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -1558,9 +1494,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "bmp-js": {
@@ -1579,6 +1515,42 @@
         "error": "7.0.2",
         "raw-body": "1.1.7",
         "safe-json-parse": "1.0.1"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+          "dev": true,
+          "requires": {
+            "bytes": "1.0.0",
+            "string_decoder": "0.10.31"
+          }
+        }
+      }
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
       }
     },
     "boolbase": {
@@ -1588,12 +1560,12 @@
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "bootstrap-sass": {
@@ -1603,13 +1575,13 @@
       "dev": true
     },
     "bower-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
-      "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+      "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "mout": "1.0.0",
+        "mout": "1.1.0",
         "optimist": "0.6.1",
         "osenv": "0.1.4",
         "untildify": "2.1.0"
@@ -1631,9 +1603,9 @@
       }
     },
     "braces": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.2.2.tgz",
-      "integrity": "sha1-JB+GjCsmkNn+vu5afIP7vyXQCxs=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+      "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
       "dev": true,
       "requires": {
         "arr-flatten": "1.1.0",
@@ -1645,7 +1617,7 @@
         "repeat-element": "1.1.2",
         "snapdragon": "0.8.1",
         "snapdragon-node": "2.1.1",
-        "split-string": "2.1.1",
+        "split-string": "3.0.2",
         "to-regex": "3.0.1"
       }
     },
@@ -1666,14 +1638,6 @@
         "json-stable-stringify": "1.0.1",
         "minimatch": "3.0.4",
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-asset-rewrite": {
@@ -1695,11 +1659,11 @@
         "broccoli-merge-trees": "1.2.4",
         "broccoli-persistent-filter": "1.4.3",
         "clone": "2.1.1",
-        "hash-for-dep": "1.2.0",
+        "hash-for-dep": "1.2.3",
         "heimdalljs-logger": "0.1.9",
         "json-stable-stringify": "1.0.1",
         "rsvp": "3.6.2",
-        "workerpool": "2.2.4"
+        "workerpool": "2.3.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -1710,23 +1674,18 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         }
       }
     },
@@ -1862,7 +1821,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -1899,25 +1858,17 @@
       }
     },
     "broccoli-builder": {
-      "version": "0.18.8",
-      "resolved": "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.8.tgz",
-      "integrity": "sha1-/lRpTVRMPN/bAQKOgC7spldJqHk=",
+      "version": "0.18.10",
+      "resolved": "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.10.tgz",
+      "integrity": "sha512-4U2jqaR5vxVR0ODxa9bWdrxz69k0WzhWfCGaTSIktJsKIVKmfD5kX1AMOUGBUaIJLJpUOd2t3XPHbXmwjnLCmQ==",
       "dev": true,
       "requires": {
         "heimdalljs": "0.2.5",
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "silent-error": "1.1.0"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-caching-writer": {
@@ -1928,18 +1879,10 @@
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
-        "rimraf": "2.6.1",
+        "debug": "2.6.9",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-clean-css": {
@@ -1967,7 +1910,7 @@
         "fast-sourcemap-concat": "1.2.3",
         "find-index": "1.1.0",
         "fs-extra": "1.0.0",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "lodash.merge": "4.6.0",
         "lodash.omit": "4.5.0",
         "lodash.uniq": "4.5.0",
@@ -2004,7 +1947,7 @@
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "fs-extra": "0.24.0"
       },
       "dependencies": {
@@ -2017,21 +1960,20 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         }
       }
     },
     "broccoli-debug": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.3.tgz",
-      "integrity": "sha512-YqpMH2QPHNtGoauVOj715dqDfurJa9O2and1UuxfzzGpM3A9mBrXeeLdWpTt8hj/Y8u8WaG/L1UBZYffPvTHVw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
+      "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
       "requires": {
         "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "minimatch": "3.0.4",
         "symlink-or-copy": "1.1.8",
         "tree-sync": "1.2.2"
       }
@@ -2042,7 +1984,7 @@
       "integrity": "sha1-x3ClqhYDL7rxtcnAM/cbnMWly1E=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "broccoli-caching-writer": "2.3.1",
         "favicons": "4.8.6",
         "lodash": "4.17.4"
@@ -2056,8 +1998,8 @@
           "requires": {
             "broccoli-kitchen-sink-helpers": "0.2.9",
             "broccoli-plugin": "1.1.0",
-            "debug": "2.6.8",
-            "rimraf": "2.6.1",
+            "debug": "2.6.9",
+            "rimraf": "2.6.2",
             "rsvp": "3.6.2",
             "walk-sync": "0.2.7"
           }
@@ -2080,7 +2022,7 @@
           "requires": {
             "promise-map-series": "0.2.3",
             "quick-temp": "0.1.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8"
           }
         },
@@ -2097,12 +2039,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
@@ -2110,7 +2046,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -2124,20 +2060,12 @@
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "broccoli-plugin": "1.3.0",
         "copy-dereference": "1.0.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "mkdirp": "0.5.1",
         "promise-map-series": "0.2.3",
         "rsvp": "3.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "broccoli-funnel": {
@@ -2148,14 +2076,14 @@
         "array-equal": "1.0.0",
         "blank-object": "1.0.2",
         "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "heimdalljs": "0.2.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "path-posix": "1.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
       }
@@ -2190,15 +2118,15 @@
       }
     },
     "broccoli-lint-eslint": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.1.0.tgz",
-      "integrity": "sha1-3M+hFQ3GJAfNZv1WphknPFR5oQ4=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.2.1.tgz",
+      "integrity": "sha512-Jvm06UvuMPa5gEH+9/Sb+QpoIodDAYzbyIUEqxniPCdA6JJooa91hQDCTJc32RUV46JNMcLhb3Dl55BdA8v5mw==",
       "dev": true,
       "requires": {
         "aot-test-generators": "0.1.0",
         "broccoli-concat": "3.2.2",
         "broccoli-persistent-filter": "1.4.3",
-        "eslint": "4.6.1",
+        "eslint": "4.11.0",
         "json-stable-stringify": "1.0.1",
         "lodash.defaultsdeep": "4.6.0",
         "md5-hex": "2.0.0"
@@ -2212,10 +2140,10 @@
         "broccoli-plugin": "1.3.0",
         "can-symlink": "1.0.0",
         "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -2225,8 +2153,8 @@
       "integrity": "sha1-kvTh+5p5HqmGJFpwd/NcxkjasJc=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.10",
-        "mime": "1.4.0"
+        "handlebars": "4.0.11",
+        "mime": "1.4.1"
       }
     },
     "broccoli-persistent-filter": {
@@ -2234,26 +2162,19 @@
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
       "requires": {
-        "async-disk-cache": "1.3.2",
+        "async-disk-cache": "1.3.3",
         "async-promise-queue": "1.0.4",
         "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.6",
-        "hash-for-dep": "1.2.0",
+        "fs-tree-diff": "0.5.7",
+        "hash-for-dep": "1.2.3",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
         "mkdirp": "0.5.1",
         "promise-map-series": "0.2.3",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "broccoli-plugin": {
@@ -2263,7 +2184,7 @@
       "requires": {
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -2287,7 +2208,7 @@
         "broccoli-caching-writer": "3.0.3",
         "include-path-searcher": "0.1.0",
         "mkdirp": "0.3.5",
-        "node-sass": "4.5.3",
+        "node-sass": "4.6.1",
         "object-assign": "2.1.1",
         "rsvp": "3.6.2"
       },
@@ -2302,12 +2223,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
           "dev": true
         }
       }
@@ -2347,8 +2262,8 @@
           "requires": {
             "broccoli-kitchen-sink-helpers": "0.2.9",
             "broccoli-plugin": "1.1.0",
-            "debug": "2.6.8",
-            "rimraf": "2.6.1",
+            "debug": "2.6.9",
+            "rimraf": "2.6.2",
             "rsvp": "3.6.2",
             "walk-sync": "0.2.7"
           }
@@ -2371,7 +2286,7 @@
           "requires": {
             "promise-map-series": "0.2.3",
             "quick-temp": "0.1.8",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8"
           }
         },
@@ -2388,12 +2303,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
@@ -2401,7 +2310,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -2412,17 +2321,17 @@
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
       "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.3",
+        "broccoli-debug": "0.6.4",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "1.2.4",
         "broccoli-persistent-filter": "1.4.3",
         "broccoli-plugin": "1.3.0",
         "chalk": "1.1.3",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "ensure-posix-path": "1.0.2",
         "fs-extra": "2.1.2",
         "minimatch": "3.0.4",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "rsvp": "3.6.2",
         "symlink-or-copy": "1.1.8",
         "walk-sync": "0.3.2"
@@ -2437,15 +2346,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -2459,13 +2368,16 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
+      }
+    },
+    "broccoli-string-replace": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
+      "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
+      "requires": {
+        "broccoli-persistent-filter": "1.4.3",
+        "minimatch": "3.0.4"
       }
     },
     "broccoli-uglify-sourcemap": {
@@ -2475,9 +2387,9 @@
       "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "lodash.merge": "4.6.0",
-        "matcher-collection": "1.0.4",
+        "matcher-collection": "1.0.5",
         "mkdirp": "0.5.1",
         "source-map-url": "0.3.0",
         "symlink-or-copy": "1.1.8",
@@ -2500,12 +2412,12 @@
       }
     },
     "browserslist": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
-      "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
+      "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "requires": {
-        "caniuse-lite": "1.0.30000726",
-        "electron-to-chromium": "1.3.20"
+        "caniuse-lite": "1.0.30000760",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "bser": {
@@ -2558,27 +2470,26 @@
       "dev": true
     },
     "bytes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cache-base": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
-      "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "0.2.3",
+        "collection-visit": "1.0.0",
         "component-emitter": "1.2.1",
         "get-value": "2.0.6",
-        "has-value": "0.3.1",
+        "has-value": "1.0.0",
         "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "set-value": "0.4.3",
+        "set-value": "2.0.0",
         "to-object-path": "0.3.0",
-        "union-value": "0.2.4",
-        "unset-value": "0.1.2"
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "calculate-cache-key-for-tree": {
@@ -2649,16 +2560,16 @@
       "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
       "dev": true,
       "requires": {
-        "browserslist": "2.4.0",
-        "caniuse-lite": "1.0.30000726",
+        "browserslist": "2.9.0",
+        "caniuse-lite": "1.0.30000760",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000726",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000726.tgz",
-      "integrity": "sha1-lmp1P6EHoJ1BMc+LPWFnI6Bsz34="
+      "version": "1.0.30000760",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz",
+      "integrity": "sha1-7HIDlXQvHH7IlH/W3SYE53qPmP8="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -2667,14 +2578,6 @@
       "dev": true,
       "requires": {
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "cardinal": {
@@ -2761,7 +2664,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2786,12 +2689,6 @@
           }
         }
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -2829,13 +2726,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -2990,20 +2887,19 @@
       "dev": true
     },
     "collection-visit": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-      "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "lazy-cache": "2.0.2",
-        "map-visit": "0.1.5",
-        "object-visit": "0.3.4"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -3049,10 +2945,10 @@
         "detective": "4.5.0",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "mkdirp": "0.5.1",
-        "private": "0.1.7",
-        "q": "1.5.0",
+        "private": "0.1.8",
+        "q": "1.5.1",
         "recast": "0.11.23"
       },
       "dependencies": {
@@ -3089,7 +2985,7 @@
           "requires": {
             "ast-types": "0.9.6",
             "esprima": "3.1.3",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "source-map": "0.5.7"
           }
         }
@@ -3114,27 +3010,27 @@
       "dev": true
     },
     "compressible": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
-      "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
       "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
     },
     "compression": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
-      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
-        "bytes": "2.5.0",
-        "compressible": "2.0.11",
-        "debug": "2.6.8",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.1"
+        "vary": "1.1.2"
       }
     },
     "concat-map": {
@@ -3187,7 +3083,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
+        "make-dir": "1.1.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -3222,7 +3118,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0"
+        "bluebird": "3.5.1"
       }
     },
     "content-disposition": {
@@ -3232,9 +3128,9 @@
       "dev": true
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "continuable-cache": {
@@ -3283,7 +3179,7 @@
       "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0"
+        "chalk": "2.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3292,24 +3188,24 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -3347,12 +3243,23 @@
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "crypto-random-string": {
@@ -3410,20 +3317,12 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -3441,6 +3340,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "deep-freeze": {
@@ -3528,7 +3433,15 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -3587,20 +3500,10 @@
         }
       }
     },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
-      }
-    },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
     "doctrine": {
@@ -3692,9 +3595,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.20",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.20.tgz",
-      "integrity": "sha1-Lu3VzLrn3cVX9orR/OnBcukV5OU="
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
     },
     "ember-ajax": {
       "version": "3.0.0",
@@ -3706,24 +3609,13 @@
       }
     },
     "ember-assign-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-assign-polyfill/-/ember-assign-polyfill-2.0.2.tgz",
-      "integrity": "sha1-leN1E76qvENW1WqETHQlCbC35/E=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-assign-polyfill/-/ember-assign-polyfill-2.1.0.tgz",
+      "integrity": "sha512-XKKejlKGF3UgZOAr3VksOrgCKroZscgA91rR5gRZk0wVOsiay3aFdkM5jeOFjfi1xmBP9wrn1i32P945Q6J4sw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.8.2",
-        "ember-cli-version-checker": "1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "5.4.1"
-          }
-        }
+        "ember-cli-version-checker": "2.1.0"
       }
     },
     "ember-ast-helpers": {
@@ -3742,12 +3634,12 @@
       "integrity": "sha1-19D4ivBnLHKYWw/p8PUFQGEb2Ds=",
       "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.3",
+        "broccoli-debug": "0.6.4",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "broccoli-stew": "1.5.0",
-        "chalk": "2.1.0",
-        "ember-assign-polyfill": "2.0.2",
+        "chalk": "2.3.0",
+        "ember-assign-polyfill": "2.1.0",
         "ember-cli-babel": "6.8.2",
         "ember-cli-build-config-editor": "0.5.1",
         "ember-cli-classlist-polyfill": "0.1.0",
@@ -3755,8 +3647,8 @@
         "ember-runtime-enumerable-includes-polyfill": "2.0.0",
         "ember-wormhole": "0.5.2",
         "findup-sync": "2.0.0",
-        "fs-extra": "4.0.1",
-        "rsvp": "4.0.1",
+        "fs-extra": "4.0.2",
+        "rsvp": "4.7.0",
         "silent-error": "1.1.0"
       },
       "dependencies": {
@@ -3766,7 +3658,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "broccoli-funnel": {
@@ -3778,15 +3670,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -3802,20 +3694,26 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
+        "rsvp": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.7.0.tgz",
+          "integrity": "sha1-3BsLGlNvfeydK+ReChKtQZfJ/ZY=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -3831,11 +3729,11 @@
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower-config": "1.4.0",
+        "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.2",
         "broccoli-brocfile-loader": "0.18.0",
-        "broccoli-builder": "0.18.8",
+        "broccoli-builder": "0.18.10",
         "broccoli-concat": "3.2.2",
         "broccoli-config-loader": "1.0.1",
         "broccoli-config-replace": "1.1.2",
@@ -3849,13 +3747,13 @@
         "capture-exit": "1.2.0",
         "chalk": "1.1.3",
         "clean-base-url": "1.0.0",
-        "compression": "1.7.0",
+        "compression": "1.7.1",
         "configstore": "3.1.1",
         "console-ui": "1.0.3",
         "core-object": "3.1.5",
         "dag-map": "2.0.2",
         "deep-freeze": "0.0.1",
-        "diff": "3.3.1",
+        "diff": "3.4.0",
         "ember-cli-broccoli-sane-watcher": "2.0.4",
         "ember-cli-is-package-missing": "1.0.0",
         "ember-cli-legacy-blueprints": "0.1.5",
@@ -3863,42 +3761,42 @@
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-preprocess-registry": "3.1.1",
         "ember-cli-string-utils": "1.1.0",
-        "ember-try": "0.2.16",
+        "ember-try": "0.2.18",
         "ensure-posix-path": "1.0.2",
         "execa": "0.7.0",
         "exists-sync": "0.0.4",
         "exit": "0.1.2",
-        "express": "4.15.4",
-        "filesize": "3.5.10",
+        "express": "4.16.2",
+        "filesize": "3.5.11",
         "find-up": "2.1.0",
         "fs-extra": "3.0.1",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "get-caller-file": "1.0.2",
         "git-repo-info": "1.4.1",
         "glob": "7.1.1",
         "heimdalljs": "0.2.5",
         "heimdalljs-fs-monitor": "0.1.0",
-        "heimdalljs-graph": "0.3.3",
+        "heimdalljs-graph": "0.3.4",
         "heimdalljs-logger": "0.1.9",
         "http-proxy": "1.16.2",
         "inflection": "1.12.0",
         "is-git-url": "1.0.0",
         "isbinaryfile": "3.0.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "leek": "0.0.24",
         "lodash.template": "4.4.0",
         "markdown-it": "8.4.0",
         "markdown-it-terminal": "0.1.0",
         "minimatch": "3.0.4",
-        "morgan": "1.8.2",
+        "morgan": "1.9.0",
         "node-modules-path": "1.0.1",
         "nopt": "3.0.6",
         "npm-package-arg": "4.2.1",
         "portfinder": "1.0.13",
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "rsvp": "3.6.2",
         "sane": "1.7.0",
         "semver": "5.4.1",
@@ -3924,15 +3822,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -3980,12 +3878,6 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -3996,16 +3888,16 @@
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-debug-macros": "0.1.11",
-        "babel-plugin-ember-modules-api-polyfill": "2.0.1",
+        "babel-plugin-ember-modules-api-polyfill": "2.2.1",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-polyfill": "6.26.0",
-        "babel-preset-env": "1.6.0",
+        "babel-preset-env": "1.6.1",
         "broccoli-babel-transpiler": "6.1.2",
-        "broccoli-debug": "0.6.3",
+        "broccoli-debug": "0.6.4",
         "broccoli-funnel": "1.2.0",
         "broccoli-source": "1.1.0",
         "clone": "2.1.1",
-        "ember-cli-version-checker": "2.0.0"
+        "ember-cli-version-checker": "2.1.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -4016,15 +3908,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -4042,14 +3934,6 @@
         "heimdalljs-logger": "0.1.9",
         "rsvp": "3.6.2",
         "sane": "1.7.0"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-cli-build-config-editor": {
@@ -4058,7 +3942,7 @@
       "integrity": "sha512-wNGVcpHbp6R+DeDHdpx+w4M+F+2cjaFDvf4ZV3VeIcHXLoxYlo0duXkbOLVKalHK/al6xO+rlZt5KqjK5Cyp0w==",
       "dev": true,
       "requires": {
-        "recast": "0.12.6"
+        "recast": "0.12.9"
       }
     },
     "ember-cli-classlist-polyfill": {
@@ -4083,15 +3967,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -4115,18 +3999,10 @@
       "integrity": "sha1-Pst7Dmf9rdHmjqugX7r/sDvNeGQ=",
       "dev": true,
       "requires": {
-        "broccoli-lint-eslint": "4.1.0",
-        "ember-cli-version-checker": "2.0.0",
+        "broccoli-lint-eslint": "4.2.1",
+        "ember-cli-version-checker": "2.1.0",
         "rsvp": "3.6.2",
         "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-cli-favicon": {
@@ -4167,7 +4043,7 @@
             "chalk": "1.1.3",
             "convert-source-map": "1.5.0",
             "core-js": "1.2.7",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "detect-indent": "3.0.1",
             "esutils": "2.0.2",
             "fs-readdir-recursive": "0.1.2",
@@ -4181,11 +4057,11 @@
             "output-file-sync": "1.1.2",
             "path-exists": "1.0.0",
             "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "regenerator": "0.8.40",
             "regexpu": "1.3.0",
             "repeating": "1.1.3",
-            "resolve": "1.4.0",
+            "resolve": "1.5.0",
             "shebang-regex": "1.0.0",
             "slash": "1.0.0",
             "source-map": "0.5.7",
@@ -4218,11 +4094,11 @@
             "broccoli-merge-trees": "1.2.4",
             "broccoli-persistent-filter": "1.4.3",
             "clone": "0.2.0",
-            "hash-for-dep": "1.2.0",
+            "hash-for-dep": "1.2.3",
             "heimdalljs-logger": "0.1.9",
             "json-stable-stringify": "1.0.1",
             "rsvp": "3.6.2",
-            "workerpool": "2.2.4"
+            "workerpool": "2.3.0"
           },
           "dependencies": {
             "clone": {
@@ -4242,15 +4118,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4293,7 +4169,7 @@
             "broccoli-funnel": "1.2.0",
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.4.0"
+            "resolve": "1.5.0"
           }
         },
         "ember-cli-version-checker": {
@@ -4368,12 +4244,6 @@
           "requires": {
             "is-finite": "1.0.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
@@ -4446,7 +4316,7 @@
             "chalk": "1.1.3",
             "convert-source-map": "1.5.0",
             "core-js": "1.2.7",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "detect-indent": "3.0.1",
             "esutils": "2.0.2",
             "fs-readdir-recursive": "0.1.2",
@@ -4460,11 +4330,11 @@
             "output-file-sync": "1.1.2",
             "path-exists": "1.0.0",
             "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "regenerator": "0.8.40",
             "regexpu": "1.3.0",
             "repeating": "1.1.3",
-            "resolve": "1.4.0",
+            "resolve": "1.5.0",
             "shebang-regex": "1.0.0",
             "slash": "1.0.0",
             "source-map": "0.5.7",
@@ -4497,11 +4367,11 @@
             "broccoli-merge-trees": "1.2.4",
             "broccoli-persistent-filter": "1.4.3",
             "clone": "0.2.0",
-            "hash-for-dep": "1.2.0",
+            "hash-for-dep": "1.2.3",
             "heimdalljs-logger": "0.1.9",
             "json-stable-stringify": "1.0.1",
             "rsvp": "3.6.2",
-            "workerpool": "2.2.4"
+            "workerpool": "2.3.0"
           },
           "dependencies": {
             "clone": {
@@ -4521,15 +4391,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4572,7 +4442,7 @@
             "broccoli-funnel": "1.2.0",
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.4.0"
+            "resolve": "1.5.0"
           }
         },
         "ember-cli-version-checker": {
@@ -4648,12 +4518,6 @@
             "is-finite": "1.0.2"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -4683,7 +4547,7 @@
       "dev": true,
       "requires": {
         "broccoli-persistent-filter": "1.4.3",
-        "hash-for-dep": "1.2.0",
+        "hash-for-dep": "1.2.3",
         "json-stable-stringify": "1.0.1",
         "strip-bom": "3.0.0"
       }
@@ -4695,8 +4559,8 @@
       "dev": true,
       "requires": {
         "babel-plugin-htmlbars-inline-precompile": "0.2.3",
-        "ember-cli-version-checker": "2.0.0",
-        "hash-for-dep": "1.2.0",
+        "ember-cli-version-checker": "2.1.0",
+        "hash-for-dep": "1.2.3",
         "heimdalljs-logger": "0.1.9",
         "silent-error": "1.1.0"
       }
@@ -4762,14 +4626,8 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
@@ -4803,7 +4661,7 @@
         "broccoli-clean-css": "1.1.0",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "1.2.4",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "ember-cli-lodash-subset": "1.0.12",
         "exists-sync": "0.0.3",
         "process-relative-require": "1.0.0",
@@ -4819,15 +4677,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -4858,11 +4716,11 @@
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-babel": "6.8.2",
         "ember-cli-test-loader": "2.2.0",
-        "ember-cli-version-checker": "2.0.0",
+        "ember-cli-version-checker": "2.1.0",
         "ember-qunit": "2.2.0",
         "qunit-notifications": "0.1.1",
-        "qunitjs": "2.4.0",
-        "resolve": "1.4.0",
+        "qunitjs": "2.4.1",
+        "resolve": "1.5.0",
         "silent-error": "1.1.0"
       },
       "dependencies": {
@@ -4897,12 +4755,6 @@
         "silent-error": "1.1.0"
       },
       "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -4932,15 +4784,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5030,11 +4882,11 @@
       }
     },
     "ember-cli-version-checker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz",
-      "integrity": "sha1-4ffY5M3NdSrDXxYR5Nqog220xMc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+      "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
       "requires": {
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "semver": "5.4.1"
       }
     },
@@ -5066,8 +4918,8 @@
         "ember-cli-babel": "6.8.2",
         "ember-cli-htmlbars": "2.0.3",
         "font-awesome": "4.7.0",
-        "fs-readdir-recursive": "1.0.0",
-        "postcss": "6.0.11"
+        "fs-readdir-recursive": "1.1.0",
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -5079,23 +4931,23 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
         },
         "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-          "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+          "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
           "dev": true
         }
       }
@@ -5107,6 +4959,51 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.8.2"
+      }
+    },
+    "ember-lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/ember-lodash/-/ember-lodash-4.17.5.tgz",
+      "integrity": "sha512-KNXi6nosrNOyYmop4J+z3lBskZQe8077nJufY7ZqjCdKNrFH9cZ0FpwANZKcYqJe+srwp4RPOW9RaMdjTdFSvw==",
+      "requires": {
+        "broccoli-debug": "0.6.4",
+        "broccoli-funnel": "1.2.0",
+        "broccoli-merge-trees": "2.0.0",
+        "broccoli-string-replace": "0.1.2",
+        "ember-cli-babel": "6.8.2",
+        "lodash-es": "4.17.4"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.9",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.7",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "merge-trees": "1.0.1"
+          }
+        }
       }
     },
     "ember-qunit": {
@@ -5129,8 +5026,8 @@
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-babel": "6.8.2",
-        "ember-cli-version-checker": "2.0.0",
-        "resolve": "1.4.0"
+        "ember-cli-version-checker": "2.1.0",
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -5142,15 +5039,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5168,9 +5065,9 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
-      "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
+      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -5201,7 +5098,7 @@
           "requires": {
             "ast-types": "0.9.6",
             "esprima": "3.1.3",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "source-map": "0.5.7"
           }
         }
@@ -5264,7 +5161,7 @@
             "chalk": "1.1.3",
             "convert-source-map": "1.5.0",
             "core-js": "1.2.7",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "detect-indent": "3.0.1",
             "esutils": "2.0.2",
             "fs-readdir-recursive": "0.1.2",
@@ -5278,11 +5175,11 @@
             "output-file-sync": "1.1.2",
             "path-exists": "1.0.0",
             "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "regenerator": "0.8.40",
             "regexpu": "1.3.0",
             "repeating": "1.1.3",
-            "resolve": "1.4.0",
+            "resolve": "1.5.0",
             "shebang-regex": "1.0.0",
             "slash": "1.0.0",
             "source-map": "0.5.7",
@@ -5315,11 +5212,11 @@
             "broccoli-merge-trees": "1.2.4",
             "broccoli-persistent-filter": "1.4.3",
             "clone": "0.2.0",
-            "hash-for-dep": "1.2.0",
+            "hash-for-dep": "1.2.3",
             "heimdalljs-logger": "0.1.9",
             "json-stable-stringify": "1.0.1",
             "rsvp": "3.6.2",
-            "workerpool": "2.2.4"
+            "workerpool": "2.3.0"
           },
           "dependencies": {
             "clone": {
@@ -5339,15 +5236,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           },
@@ -5390,7 +5287,7 @@
             "broccoli-funnel": "1.2.0",
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.4.0"
+            "resolve": "1.5.0"
           }
         },
         "ember-cli-htmlbars": {
@@ -5401,7 +5298,7 @@
           "requires": {
             "broccoli-persistent-filter": "1.4.3",
             "ember-cli-version-checker": "1.3.1",
-            "hash-for-dep": "1.2.0",
+            "hash-for-dep": "1.2.3",
             "json-stable-stringify": "1.0.1",
             "strip-bom": "2.0.0"
           }
@@ -5479,12 +5376,6 @@
             "is-finite": "1.0.2"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -5517,16 +5408,16 @@
       }
     },
     "ember-source": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.15.0.tgz",
-      "integrity": "sha1-kBy+Or7gkpI3Kwb2qo3TQmg74tU=",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.15.3.tgz",
+      "integrity": "sha1-Bk01ivQndCadRQkcxTFt9+Nu35w=",
       "dev": true,
       "requires": {
-        "@glimmer/compiler": "0.25.3",
-        "@glimmer/node": "0.25.3",
-        "@glimmer/reference": "0.25.3",
-        "@glimmer/runtime": "0.25.3",
-        "@glimmer/util": "0.25.3",
+        "@glimmer/compiler": "0.25.6",
+        "@glimmer/node": "0.25.6",
+        "@glimmer/reference": "0.25.6",
+        "@glimmer/runtime": "0.25.6",
+        "@glimmer/util": "0.25.6",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-get-component-path-option": "1.0.0",
@@ -5538,24 +5429,24 @@
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "1.3.1",
         "ember-router-generator": "1.2.3",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "jquery": "3.2.1",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "rsvp": "3.6.2",
         "simple-dom": "0.3.2",
-        "simple-html-tokenizer": "0.4.1"
+        "simple-html-tokenizer": "0.4.3"
       },
       "dependencies": {
         "@glimmer/compiler": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.25.3.tgz",
-          "integrity": "sha1-JesGOU87ocH65a8lyc996ywR704=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.25.6.tgz",
+          "integrity": "sha512-Y0fjyd89458CI/ZGC96EjrH8aq/RGHWpqLu7jVwL6E+yP8fa/IqhHIJc0mIYcvaBmzOBHRkM0ojHcOGh27RexQ==",
           "dev": true,
           "requires": {
-            "@glimmer/interfaces": "0.25.3",
-            "@glimmer/syntax": "0.25.3",
-            "@glimmer/util": "0.25.3",
-            "@glimmer/wire-format": "0.25.3",
+            "@glimmer/interfaces": "0.25.6",
+            "@glimmer/syntax": "0.25.6",
+            "@glimmer/util": "0.25.6",
+            "@glimmer/wire-format": "0.25.6",
             "simple-html-tokenizer": "0.3.0"
           },
           "dependencies": {
@@ -5568,23 +5459,23 @@
           }
         },
         "@glimmer/interfaces": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.25.3.tgz",
-          "integrity": "sha1-jEYLKK1aF+qhcS5qp7jrtJc4w48=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.25.6.tgz",
+          "integrity": "sha512-upd9kjJMlKvbz76hvC28mbF4tFXSR5vsjVJLXkk404EvNXVCOgIaKepMfy2SGGSWCiHai1uVIbT0YWNidIieAg==",
           "dev": true,
           "requires": {
-            "@glimmer/wire-format": "0.25.3"
+            "@glimmer/wire-format": "0.25.6"
           }
         },
         "@glimmer/syntax": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.25.3.tgz",
-          "integrity": "sha1-s/ilm+5hb9YAMB13jeO2Sb93A24=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.25.6.tgz",
+          "integrity": "sha512-VDEvtpTWv3g897vBrOYnOnObg4tkj/EiShA6qebPzFq5KJT+zzAyoStSqR+c1Dc3k+k3obQXPtTFZ/hF9Tcs3A==",
           "dev": true,
           "requires": {
-            "@glimmer/interfaces": "0.25.3",
-            "@glimmer/util": "0.25.3",
-            "handlebars": "4.0.10",
+            "@glimmer/interfaces": "0.25.6",
+            "@glimmer/util": "0.25.6",
+            "handlebars": "4.0.11",
             "simple-html-tokenizer": "0.3.0"
           },
           "dependencies": {
@@ -5597,18 +5488,18 @@
           }
         },
         "@glimmer/util": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
-          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.6.tgz",
+          "integrity": "sha512-Ip1qpA5WWuTRUb/pecI85aVmOwA8ZBVQKwEml4P56Ia8X6yEp0wtqnER02L9gKTzaeUXjsJnoW90upSLTxy6GQ==",
           "dev": true
         },
         "@glimmer/wire-format": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.25.3.tgz",
-          "integrity": "sha1-BGaSs6JqMKSYcSJmzQvbR9dxDzc=",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.25.6.tgz",
+          "integrity": "sha512-b8P7TGt2Hv90O+B8eJ1h7FtoMUtQpaAJMdwXiIK6D8xh+HGpi4jgG/HHUazo37a4B5eTaJPy7R/dz7ugF3blVQ==",
           "dev": true,
           "requires": {
-            "@glimmer/util": "0.25.3"
+            "@glimmer/util": "0.25.6"
           }
         },
         "broccoli-funnel": {
@@ -5620,15 +5511,15 @@
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "exists-sync": "0.0.4",
             "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
+            "fs-tree-diff": "0.5.7",
             "heimdalljs": "0.2.5",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "path-posix": "1.0.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8",
             "walk-sync": "0.3.2"
           }
@@ -5652,16 +5543,10 @@
             "semver": "5.4.1"
           }
         },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
         "simple-html-tokenizer": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
-          "integrity": "sha1-AomIu3/osuZkVnbYIFJYfUQLAtM=",
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz",
+          "integrity": "sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw==",
           "dev": true
         }
       }
@@ -5673,22 +5558,22 @@
       "dev": true
     },
     "ember-try": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.16.tgz",
-      "integrity": "sha512-AQZEwMv6BIrVq/ysRcWULvw5tr6RQtUfSYuCpvtdxxJWho74d16YKhGyWAdID+QSmWHrVVGx+O1kDgjf7YKu9A==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.18.tgz",
+      "integrity": "sha512-kOmInCuw7Wa1PyRoomzP9IVe53WsEaDOKPrY44ahLQL5EuO6CryUHZaphiLHWd7oodpa/MK5rFs2HpmtyANxkA==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-table2": "0.2.0",
         "core-object": "1.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "ember-cli-version-checker": "1.3.1",
-        "ember-try-config": "2.1.0",
+        "ember-try-config": "2.2.0",
         "extend": "3.0.0",
         "fs-extra": "0.26.7",
         "promise-map-series": "0.2.3",
-        "resolve": "1.4.0",
-        "rimraf": "2.6.1",
+        "resolve": "1.5.0",
+        "rimraf": "2.6.2",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
       },
@@ -5718,35 +5603,21 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         }
       }
     },
     "ember-try-config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.1.0.tgz",
-      "integrity": "sha1-4OFWIppUI0aljub2rWBRBMmO3+A=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
+      "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "node-fetch": "1.7.2",
+        "node-fetch": "1.7.3",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "ember-wormhole": {
@@ -5767,7 +5638,7 @@
           "requires": {
             "broccoli-persistent-filter": "1.4.3",
             "ember-cli-version-checker": "1.3.1",
-            "hash-for-dep": "1.2.0",
+            "hash-for-dep": "1.2.3",
             "json-stable-stringify": "1.0.1",
             "strip-bom": "2.0.0"
           }
@@ -5804,7 +5675,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18"
+        "iconv-lite": "0.4.19"
       }
     },
     "engine.io": {
@@ -5972,20 +5843,20 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
-      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
+      "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.3.0",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -5993,12 +5864,12 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.3",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -6006,20 +5877,20 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
           "dev": true
         },
         "ansi-regex": {
@@ -6034,18 +5905,18 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "cli-cursor": {
@@ -6057,15 +5928,24 @@
             "restore-cursor": "2.0.0"
           }
         },
-        "external-editor": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-          "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.18",
-            "jschardet": "1.5.1",
-            "tmp": "0.0.31"
+            "ms": "2.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+          "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19",
+            "jschardet": "1.6.0",
+            "tmp": "0.0.33"
           }
         },
         "figures": {
@@ -6078,16 +5958,16 @@
           }
         },
         "inquirer": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
-          "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "2.0.0",
-            "chalk": "2.1.0",
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
-            "external-editor": "2.0.4",
+            "external-editor": "2.0.5",
             "figures": "2.0.0",
             "lodash": "4.17.4",
             "mute-stream": "0.0.7",
@@ -6150,18 +6030,18 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
         },
         "tmp": {
-          "version": "0.0.31",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-          "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2"
@@ -6180,12 +6060,12 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -6226,9 +6106,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter3": {
@@ -6244,9 +6124,9 @@
       "dev": true
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
@@ -6302,7 +6182,7 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
@@ -6328,13 +6208,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -6385,7 +6265,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6400,39 +6280,41 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.4",
-        "fresh": "0.5.0",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       }
     },
     "extend": {
@@ -6472,89 +6354,33 @@
       }
     },
     "extglob": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-1.1.0.tgz",
-      "integrity": "sha1-Bni04s5FwOTlD15er7Gw2rW05CQ=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.2.tgz",
+      "integrity": "sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==",
       "dev": true,
       "requires": {
         "array-unique": "0.3.2",
-        "define-property": "0.2.5",
+        "define-property": "1.0.0",
         "expand-brackets": "2.1.4",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
-        "to-regex": "2.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
-          "dev": true
-        },
-        "to-regex": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz",
-          "integrity": "sha1-4606QM/hGVWaBa6kPkyu+sxekB0=",
-          "dev": true,
-          "requires": {
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "regex-not": "0.1.2"
-          },
-          "dependencies": {
-            "regex-not": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz",
-              "integrity": "sha1-vH8cSUSxGINT0H3uuRK5TgreJds=",
-              "dev": true
-            }
-          }
-        }
+        "to-regex": "3.0.1"
       }
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
         "mkdirp": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
@@ -6563,12 +6389,6 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -6582,6 +6402,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -6612,7 +6438,7 @@
         "rsvp": "3.6.2",
         "source-map": "0.4.4",
         "source-map-url": "0.3.0",
-        "sourcemap-validator": "1.0.5"
+        "sourcemap-validator": "1.0.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6650,7 +6476,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "has-ansi": {
@@ -6661,12 +6487,6 @@
           "requires": {
             "ansi-regex": "0.2.1"
           }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
@@ -6717,7 +6537,7 @@
       "requires": {
         "async": "1.5.2",
         "cheerio": "0.19.0",
-        "clone": "1.0.2",
+        "clone": "1.0.3",
         "colors": "1.1.2",
         "harmony-reflect": "1.5.1",
         "image-size": "0.4.0",
@@ -6742,9 +6562,9 @@
           "dev": true
         },
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
           "dev": true
         }
       }
@@ -6755,7 +6575,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -6792,7 +6612,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -6809,9 +6629,9 @@
       "dev": true
     },
     "filesize": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz",
-      "integrity": "sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8=",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
+      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
       "dev": true
     },
     "fill-range": {
@@ -6827,16 +6647,16 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
@@ -6873,7 +6693,7 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.0.4",
+        "micromatch": "3.1.4",
         "resolve-dir": "1.0.1"
       }
     },
@@ -6899,9 +6719,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -6947,9 +6767,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
@@ -6958,9 +6778,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
@@ -6973,9 +6793,9 @@
       }
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-exists-sync": {
@@ -6985,20 +6805,20 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
-      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       },
       "dependencies": {
         "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -7013,26 +6833,14 @@
       "dev": true
     },
     "fs-tree-diff": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz",
-      "integrity": "sha1-NCZldJ6NykBoALZyJoyPUHPz5iM=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
+      "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
       "requires": {
         "heimdalljs-logger": "0.1.9",
         "object-assign": "4.1.1",
         "path-posix": "1.0.0",
         "symlink-or-copy": "1.1.8"
-      }
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "1.0.34"
       }
     },
     "fs.realpath": {
@@ -7041,27 +6849,25 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7071,21 +6877,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7095,49 +6898,42 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7146,8 +6942,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -7155,8 +6950,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -7164,8 +6958,7 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -7174,34 +6967,29 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -7209,36 +6997,30 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7247,8 +7029,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7256,8 +7037,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7266,28 +7046,30 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7296,28 +7078,24 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7328,14 +7106,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -7346,8 +7122,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7358,8 +7133,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7375,8 +7149,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7385,8 +7158,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7394,8 +7166,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7408,21 +7179,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7432,17 +7200,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -7452,14 +7217,12 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7470,8 +7233,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -7480,21 +7242,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -7502,28 +7261,24 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7532,22 +7287,19 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7556,22 +7308,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7583,8 +7332,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7592,14 +7340,12 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -7607,8 +7353,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -7616,14 +7361,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7631,18 +7374,18 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "version": "0.6.39",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -7656,8 +7399,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7667,8 +7409,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7680,28 +7421,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -7709,22 +7446,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7734,41 +7468,35 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7780,8 +7508,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7789,8 +7516,7 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -7804,8 +7530,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7835,8 +7560,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -7844,45 +7568,38 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7899,8 +7616,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7908,8 +7624,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -7919,8 +7634,7 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -7928,15 +7642,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -7944,15 +7656,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -7962,8 +7672,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7979,8 +7688,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7989,8 +7697,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7999,35 +7706,30 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8036,8 +7738,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8046,8 +7747,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -8061,28 +7761,7 @@
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
-    },
-    "fstream-npm": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.0.7.tgz",
-      "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
-      "dev": true,
-      "requires": {
-        "fstream-ignore": "1.0.5",
-        "inherits": "2.0.3"
+        "rimraf": "2.6.2"
       }
     },
     "functional-red-black-tree": {
@@ -8097,7 +7776,7 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.2",
+        "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
         "has-unicode": "2.0.1",
         "object-assign": "4.1.1",
@@ -8147,21 +7826,20 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "git-repo-info": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.4.1.tgz",
-      "integrity": "sha1-KgcoIyVKr2L88HZgB9e2ZRvUGUM=",
-      "dev": true
+      "integrity": "sha1-KgcoIyVKr2L88HZgB9e2ZRvUGUM="
+    },
+    "git-repo-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-1.0.0.tgz",
+      "integrity": "sha512-/u4D5oAhBM9dheHy2Vg4p8EjJXqI/hqcpTYQ6L37lfDt1hvTBCpR1OXaDprMbJfmQ0EezFZgE7ZORE4pChVjkw==",
+      "requires": {
+        "git-repo-info": "1.4.1"
+      }
     },
     "git-tools": {
       "version": "0.1.4",
@@ -8289,6 +7967,14 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "globule": {
@@ -8321,9 +8007,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -8350,31 +8036,19 @@
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        }
+        "ajv": "5.3.0",
+        "har-schema": "2.0.0"
       }
     },
     "harmony-reflect": {
@@ -8427,42 +8101,46 @@
       "dev": true
     },
     "has-value": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
         "get-value": "2.0.6",
-        "has-values": "0.1.4",
-        "isobject": "2.1.0"
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "isarray": "1.0.0"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
-    "has-values": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-      "dev": true
-    },
     "hash-for-dep": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.0.tgz",
-      "integrity": "sha512-nTAMv4FEqSmV/u/LnPnw0YZJP0Qve7lLv5D8q5Zu441gI/lBZCq3BwnoZjlOn/HBLoK9DgyY+qVhCzxb1dAAiA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+      "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "hasha": {
@@ -8476,15 +8154,15 @@
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
       }
     },
     "heimdalljs": {
@@ -8513,9 +8191,9 @@
       }
     },
     "heimdalljs-graph": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/heimdalljs-graph/-/heimdalljs-graph-0.3.3.tgz",
-      "integrity": "sha1-6oAdu6ZZyNUi/hy4Oy1gVybkkY8=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz",
+      "integrity": "sha512-2DXgPIxdatgtBOjlh5qeVeHIGMTC2V9ujEvUhVJBVOVwqnU41g1OuGaRugLi6rvk0E+u1koYkfPeptybV8ZJ4g==",
       "dev": true
     },
     "heimdalljs-logger": {
@@ -8523,14 +8201,14 @@
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "heimdalljs": "0.2.5"
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
       "dev": true
     },
     "home-or-tmp": {
@@ -8616,7 +8294,21 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
+    },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
     },
     "http-proxy": {
       "version": "1.16.2",
@@ -8629,32 +8321,26 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-      "dev": true
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "image-size": {
@@ -8786,9 +8472,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -8806,7 +8492,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8827,9 +8513,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -8856,7 +8542,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8869,13 +8555,13 @@
       "requires": {
         "is-accessor-descriptor": "0.1.6",
         "is-data-descriptor": "0.1.4",
-        "kind-of": "5.0.2"
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -8969,7 +8655,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -9140,12 +8826,12 @@
         "file-type": "3.9.0",
         "jpeg-js": "0.2.0",
         "load-bmfont": "1.3.0",
-        "mime": "1.4.0",
+        "mime": "1.4.1",
         "mkdirp": "0.5.1",
         "pixelmatch": "4.0.2",
         "pngjs": "3.3.0",
         "read-chunk": "1.0.1",
-        "request": "2.81.0",
+        "request": "2.83.0",
         "stream-to-buffer": "0.1.0",
         "tinycolor2": "1.4.1",
         "url-regex": "3.2.0"
@@ -9164,9 +8850,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
     },
     "js-reporters": {
@@ -9181,9 +8867,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -9198,21 +8884,15 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
       "dev": true
     },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -9233,6 +8913,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -9280,14 +8966,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "kew": {
@@ -9297,13 +8975,10 @@
       "dev": true
     },
     "kind-of": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.0.tgz",
+      "integrity": "sha512-sUd5AnFyOPh+RW+ZIHd1FHuwM4OFvhKCPVxxhamLxWLpmv1xQ394lzRMmhLQOiMpXvnB64YRLezWaJi5xGk7Dg==",
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
@@ -9338,17 +9013,9 @@
       "integrity": "sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "lodash.assign": "3.2.0",
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        }
       }
     },
     "leven": {
@@ -9389,7 +9056,7 @@
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "1.4.0",
+        "mime": "1.4.1",
         "parse-bmfont-ascii": "1.0.6",
         "parse-bmfont-binary": "1.0.6",
         "parse-bmfont-xml": "1.1.3",
@@ -9410,6 +9077,12 @@
         "strip-bom": "2.0.0"
       },
       "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -9441,6 +9114,11 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -9835,24 +9513,6 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -9962,12 +9622,12 @@
       "dev": true
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
       }
     },
     "makeerror": {
@@ -9992,13 +9652,12 @@
       "dev": true
     },
     "map-visit": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-      "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "lazy-cache": "2.0.2",
-        "object-visit": "0.3.4"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-it": {
@@ -10033,15 +9692,15 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
     },
     "matcher-collection": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
-      "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
       "requires": {
         "minimatch": "3.0.4"
       }
@@ -10141,13 +9800,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-      "dev": true,
       "requires": {
         "can-symlink": "1.0.0",
-        "fs-tree-diff": "0.5.6",
+        "fs-tree-diff": "0.5.7",
         "heimdalljs": "0.2.5",
         "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "symlink-or-copy": "1.1.8"
       }
     },
@@ -10158,20 +9816,20 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.0.4.tgz",
-      "integrity": "sha1-FUPx0EgTRHrIUgAcX1qTNAF4bR0=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.4.tgz",
+      "integrity": "sha512-kFRtviKYoAJT+t7HggMl0tBFGNAKLw/S7N+CO9qfEQyisob1Oy4pao+geRbkyeEd+V9aOkvZ4mhuyPvI/q9Sfg==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "braces": "2.2.2",
+        "braces": "2.3.0",
         "define-property": "1.0.0",
         "extend-shallow": "2.0.1",
-        "extglob": "1.1.0",
+        "extglob": "2.0.2",
         "fragment-cache": "0.2.1",
-        "kind-of": "4.0.0",
-        "nanomatch": "1.2.0",
+        "kind-of": "6.0.0",
+        "nanomatch": "1.2.5",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
@@ -10179,9 +9837,9 @@
       }
     },
     "mime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
-      "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -10251,9 +9909,9 @@
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
       "dev": true
     },
     "moment-timezone": {
@@ -10262,26 +9920,26 @@
       "integrity": "sha1-PvR4VrAtU7cYoQpewgI6opnge/U=",
       "dev": true,
       "requires": {
-        "moment": "2.18.1"
+        "moment": "2.19.2"
       }
     },
     "morgan": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
-      "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "1.1.0",
-        "debug": "2.6.8",
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
       }
     },
     "mout": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
-      "integrity": "sha1-m98dSvV9ZtR8s1OmM1oygQmOFQE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+      "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
       "dev": true
     },
     "ms": {
@@ -10308,9 +9966,9 @@
       "dev": true
     },
     "nanomatch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.0.tgz",
-      "integrity": "sha1-dv2z1K52F+N3GeekBHuECFfAyxw=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.5.tgz",
+      "integrity": "sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -10318,13 +9976,20 @@
         "define-property": "1.0.0",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
-        "is-extglob": "2.1.1",
         "is-odd": "1.0.0",
-        "kind-of": "4.0.0",
+        "kind-of": "5.1.0",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
         "snapdragon": "0.8.1",
         "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "natural-compare": {
@@ -10340,9 +10005,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -10363,8 +10028,8 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
         "which": "1.3.0"
@@ -10430,9 +10095,9 @@
       }
     },
     "node-sass": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.1.tgz",
+      "integrity": "sha512-0zQQ7tjEK5W8RfW9LiQrkzfo7uLZ0QtZGV69rdKn5cFzdweHLJ14lR6xLPvI6UimkXMO8m0qDsXwUCNdnqV3sA==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -10450,7 +10115,7 @@
         "nan": "2.7.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.81.0",
+        "request": "2.83.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
       },
@@ -10489,7 +10154,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -10528,21 +10193,21 @@
         "async-some": "1.0.2",
         "chownr": "1.0.1",
         "cmd-shim": "2.0.1",
-        "columnify": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+        "columnify": "1.5.4",
         "config-chain": "1.1.9",
         "debuglog": "1.0.1",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
         "fs-vacuum": "1.2.7",
-        "fs-write-stream-atomic": "1.0.10",
+        "fs-write-stream-atomic": "1.0.8",
         "fstream": "1.0.8",
         "fstream-npm": "1.0.7",
-        "glob": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+        "glob": "6.0.3",
         "graceful-fs": "4.1.2",
-        "has-unicode": "file:../has-unicode",
-        "hosted-git-info": "2.1.5",
+        "has-unicode": "2.0.0",
+        "hosted-git-info": "2.1.4",
         "iferr": "0.1.5",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "imurmurhash": "0.1.4",
         "inflight": "1.0.4",
         "inherits": "2.0.1",
         "ini": "1.3.4",
@@ -10563,32 +10228,32 @@
         "lodash.uniq": "3.2.2",
         "lodash.without": "3.2.1",
         "mkdirp": "0.5.1",
-        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "node-gyp": "3.2.1",
+        "nopt": "3.0.6",
         "normalize-git-url": "3.0.1",
         "normalize-package-data": "2.3.5",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "2.0.1",
-        "npm-package-arg": "4.1.1",
+        "npm-package-arg": "4.1.0",
         "npm-registry-client": "7.0.9",
         "npm-user-validate": "0.1.2",
-        "npmlog": "2.0.4",
-        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+        "npmlog": "2.0.0",
+        "once": "1.3.3",
         "opener": "1.4.1",
         "osenv": "0.1.3",
         "path-is-inside": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
+        "read-package-json": "2.0.2",
         "read-package-tree": "5.1.2",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+        "readable-stream": "2.0.5",
         "readdir-scoped-modules": "1.0.2",
-        "realize-package-specifier": "3.0.3",
-        "request": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+        "realize-package-specifier": "3.0.1",
+        "request": "2.67.0",
         "retry": "0.8.0",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+        "rimraf": "2.5.0",
+        "semver": "5.1.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "1.0.0",
@@ -10597,61 +10262,61 @@
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
-        "unique-filename": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+        "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "2.2.2",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
+        "which": "1.2.1",
         "wrappy": "1.0.1",
         "write-file-atomic": "1.1.4"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+          "bundled": true,
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.1.tgz",
-          "integrity": "sha1-xKwsxb7PuLCZ3n758CeQ59Mtme8=",
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
+        },
+        "async-some": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3"
+          }
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz",
-          "integrity": "sha1-RRKjc9I5FnmuxRrR1HM1Wem4XUo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "3.0.8",
@@ -10660,15 +10325,14 @@
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "columnify": {
-          "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "version": "1.5.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "3.0.0",
@@ -10677,8 +10341,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "defaults": "1.0.3"
@@ -10686,8 +10349,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "clone": "1.0.2"
@@ -10695,8 +10357,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10707,8 +10368,7 @@
         },
         "config-chain": {
           "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-          "integrity": "sha1-Oax9TcqE+q2SYSTFTP8lpTqov24=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "1.3.4",
@@ -10717,99 +10377,160 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+          "bundled": true,
           "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.3",
+            "wrappy": "1.0.1"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.7.tgz",
-          "integrity": "sha1-deUB+dKIm6L+n+Evk2ul2tUMo1o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
             "path-is-inside": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz"
+            "rimraf": "2.5.0"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.0.5"
           }
         },
         "fstream": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "integrity": "sha1-fo16c6uzZH7zbkuKFcqAHboD0Dg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
             "inherits": "2.0.1",
             "mkdirp": "0.5.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz"
+            "rimraf": "2.5.0"
           }
         },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+        "fstream-npm": {
+          "version": "1.0.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "file:../has-unicode",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "fstream-ignore": "1.0.3",
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "fstream-ignore": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fstream": "1.0.8",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.1"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.2.1",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-          "integrity": "sha1-XwLNiVh85YsVSuCFXeAqLmOYb8o=",
+          "version": "6.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "1.0.4",
             "inherits": "2.0.1",
             "minimatch": "3.0.0",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "path-is-absolute": "1.0.0"
           },
           "dependencies": {
             "minimatch": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                "brace-expansion": "1.1.2"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                  "version": "1.1.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                    "balanced-match": "0.3.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                      "version": "0.3.0",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10818,74 +10539,66 @@
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
+          "bundled": true,
           "dev": true
         },
         "has-unicode": {
-          "version": "file:../has-unicode",
-          "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+          "version": "2.1.4",
+          "bundled": true,
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "wrappy": "1.0.1"
           }
         },
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.1.tgz",
-          "integrity": "sha1-oo4FtbrrM2PNRz32jTDTqAUjoxw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "5.0.15",
-            "npm-package-arg": "4.1.1",
+            "npm-package-arg": "4.1.0",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "read-package-json": "2.0.2",
+            "semver": "5.1.0",
             "validate-npm-package-license": "3.0.1",
             "validate-npm-package-name": "2.2.2"
           },
@@ -10899,14 +10612,13 @@
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
                 "minimatch": "3.0.4",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                "once": "1.3.3",
                 "path-is-absolute": "1.0.1"
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "read": "1.0.7"
@@ -10914,28 +10626,19 @@
             }
           }
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
-          "integrity": "sha1-ISP6DbLWnCjVvrHB821hUip0AjQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseindexof": "3.1.0",
@@ -10945,20 +10648,17 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+          "bundled": true,
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+          "bundled": true,
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
@@ -10966,14 +10666,12 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "bundled": true,
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseclone": "3.3.0",
@@ -10982,8 +10680,7 @@
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-              "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._arraycopy": "3.0.0",
@@ -10996,20 +10693,17 @@
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-                  "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._arrayeach": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-                  "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._basecopy": "3.0.1",
@@ -11018,16 +10712,14 @@
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-                  "integrity": "sha1-Okzs5bcDHq54pEHFQWuQh47u5aE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11036,20 +10728,17 @@
         },
         "lodash.isarguments": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-          "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA=",
+          "bundled": true,
           "dev": true
         },
         "lodash.isarray": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "bundled": true,
           "dev": true
         },
         "lodash.keys": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1",
@@ -11059,14 +10748,12 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "bundled": true,
           "dev": true
         },
         "lodash.union": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
-          "integrity": "sha1-pKMGb8Fdan+BUczpvf5j3Of1vP8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._baseflatten": "3.1.4",
@@ -11076,8 +10763,7 @@
           "dependencies": {
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.isarguments": "3.0.4",
@@ -11088,8 +10774,7 @@
         },
         "lodash.uniq": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
-          "integrity": "sha1-FGw28l510ZUBukAuiLoUk39jzYs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._basecallback": "3.3.1",
@@ -11101,8 +10786,7 @@
           "dependencies": {
             "lodash._basecallback": {
               "version": "3.3.1",
-              "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-              "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._baseisequal": "3.0.7",
@@ -11113,8 +10797,7 @@
               "dependencies": {
                 "lodash._baseisequal": {
                   "version": "3.0.7",
-                  "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-                  "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.isarray": "3.0.4",
@@ -11124,16 +10807,14 @@
                   "dependencies": {
                     "lodash.istypedarray": {
                       "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
-                      "integrity": "sha1-k5exE8FfQk8yCvBsqlnMSV4gk84=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "lodash.pairs": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-                  "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash.keys": "3.1.2"
@@ -11143,16 +10824,14 @@
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash.without": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-3.2.1.tgz",
-          "integrity": "sha1-1pYUs1EuUilLarq3gufKllOM6BY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._basedifference": "3.0.3",
@@ -11161,8 +10840,7 @@
           "dependencies": {
             "lodash._basedifference": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-              "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash._baseindexof": "3.1.0",
@@ -11174,8 +10852,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -11183,71 +10860,68 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "node-gyp": {
-          "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
-          "integrity": "sha1-9d1WmXClCEZMw8Fdfp6NLehjjdU=",
+          "version": "3.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream": "1.0.8",
             "glob": "4.5.3",
             "graceful-fs": "4.1.2",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+            "minimatch": "1.0.0",
             "mkdirp": "0.5.1",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "nopt": "3.0.6",
             "npmlog": "1.2.1",
             "osenv": "0.1.3",
             "path-array": "1.0.0",
-            "request": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "request": "2.67.0",
+            "rimraf": "2.5.0",
+            "semver": "5.1.0",
             "tar": "2.2.1",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.1.tgz"
+            "which": "1.2.1"
           },
           "dependencies": {
             "glob": {
               "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
                 "minimatch": "2.0.10",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                "once": "1.3.3"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                    "brace-expansion": "1.1.2"
                   },
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "version": "1.1.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "version": "0.3.0",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
-                          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11263,30 +10937,29 @@
               "dev": true
             },
             "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "version": "2.7.3",
+                  "bundled": true,
                   "dev": true
                 },
                 "sigmund": {
-                  "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "version": "1.0.1",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "npmlog": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-              "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "0.3.0",
@@ -11296,14 +10969,12 @@
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
-                  "integrity": "sha1-dLLx8YfIVTx/lQFby3YAn7Q9OOA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                  "integrity": "sha1-Un/jife8upCAYQa5kkTqoH6Ib4U=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "0.1.0",
@@ -11312,35 +10983,33 @@
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
-                      "integrity": "sha1-tLV74RoWU1F6BLJ/CUm9wyff45A=",
+                      "bundled": true,
                       "dev": true
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "core-util-is": "1.0.2",
                         "inherits": "2.0.1",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
                       },
                       "dependencies": {
                         "core-util-is": {
-                          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "version": "1.0.2",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
-                          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
-                          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "version": "0.10.31",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11349,8 +11018,7 @@
                 },
                 "gauge": {
                   "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                  "integrity": "sha1-BbZzChmo/K08NAoULwlFIio/gVs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi": "0.3.0",
@@ -11362,8 +11030,7 @@
                   "dependencies": {
                     "lodash.pad": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                      "integrity": "sha1-LgeOvDOzMdK6NL+HMq8Sn9XARiQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11372,14 +11039,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11387,8 +11052,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11400,8 +11064,7 @@
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                      "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11410,14 +11073,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11425,8 +11086,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11438,8 +11098,7 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                      "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11448,14 +11107,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11463,8 +11120,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11480,8 +11136,7 @@
             },
             "path-array": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
-              "integrity": "sha1-bBQTDDMITwFQVTxlezg5erZ6qk4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "array-index": "0.1.1"
@@ -11489,24 +11144,23 @@
               "dependencies": {
                 "array-index": {
                   "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
-                  "integrity": "sha1-TV6vBsw9klhHzXPRU1whe6MG0+E=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                    "debug": "2.2.0"
                   },
                   "dependencies": {
                     "debug": {
-                      "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                      "version": "2.2.0",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        "ms": "0.7.1"
                       },
                       "dependencies": {
                         "ms": {
-                          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                          "version": "0.7.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11518,8 +11172,8 @@
           }
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "3.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1.0.7"
@@ -11527,26 +11181,23 @@
         },
         "normalize-git-url": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.1.tgz",
-          "integrity": "sha1-1A1BnQWhWHAnHlBTTbt7jM2bClw=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
+            "hosted-git-info": "2.1.4",
             "is-builtin-module": "1.0.0",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "validate-npm-package-license": "3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "builtin-modules": "1.1.0"
@@ -11554,8 +11205,7 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                  "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11564,18 +11214,16 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-2.0.1.tgz",
-          "integrity": "sha1-qTVAtT8E+p2RbScz1lQfbbfYjkY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "npmlog": "1.2.1",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+            "semver": "5.1.0"
           },
           "dependencies": {
             "has-unicode": {
@@ -11586,8 +11234,7 @@
             },
             "npmlog": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-              "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "0.3.0",
@@ -11597,14 +11244,12 @@
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
-                  "integrity": "sha1-dLLx8YfIVTx/lQFby3YAn7Q9OOA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                  "integrity": "sha1-Un/jife8upCAYQa5kkTqoH6Ib4U=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "0.1.0",
@@ -11613,14 +11258,12 @@
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
-                      "integrity": "sha1-tLV74RoWU1F6BLJ/CUm9wyff45A=",
+                      "bundled": true,
                       "dev": true
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "core-util-is": "1.0.1",
@@ -11631,20 +11274,17 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11653,8 +11293,7 @@
                 },
                 "gauge": {
                   "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                  "integrity": "sha1-BbZzChmo/K08NAoULwlFIio/gVs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi": "0.3.0",
@@ -11666,8 +11305,7 @@
                   "dependencies": {
                     "lodash.pad": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                      "integrity": "sha1-LgeOvDOzMdK6NL+HMq8Sn9XARiQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11676,14 +11314,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11691,8 +11327,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11704,8 +11339,7 @@
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                      "integrity": "sha1-FQFR8eAkXtuhXVCvLXHx1c/0ZTA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11714,14 +11348,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11729,8 +11361,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11742,8 +11373,7 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                      "integrity": "sha1-efd3C6qjlzjAQK61Rl6NiPKqzsA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._basetostring": "3.0.1",
@@ -11752,14 +11382,12 @@
                       "dependencies": {
                         "lodash._basetostring": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                          "bundled": true,
                           "dev": true
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "integrity": "sha1-SQe0OFla3FTuiTVSemxCTALIGoc=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "lodash.repeat": "3.0.1"
@@ -11767,8 +11395,7 @@
                           "dependencies": {
                             "lodash.repeat": {
                               "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
-                              "integrity": "sha1-9LmNx+9nJWzmHnh04YZe2yCODt8=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "lodash._basetostring": "3.0.1"
@@ -11785,35 +11412,244 @@
           }
         },
         "npm-package-arg": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.1.tgz",
-          "integrity": "sha1-htncqYW0xeXVl3Lf1d5pGZmKSVo=",
+          "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+            "hosted-git-info": "2.1.4",
+            "semver": "5.1.0"
+          }
+        },
+        "npm-registry-client": {
+          "version": "7.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "concat-stream": "1.5.1",
+            "graceful-fs": "4.1.2",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.3.5",
+            "npm-package-arg": "4.1.0",
+            "npmlog": "2.0.0",
+            "once": "1.3.3",
+            "request": "2.67.0",
+            "retry": "0.8.0",
+            "rimraf": "2.5.0",
+            "semver": "5.1.0",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "readable-stream": "2.0.5",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "npm-user-validate": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz",
-          "integrity": "sha1-1YXaC0fJ9BqebKaEtv2EukHr6H0=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
+            "ansi": "0.3.0",
+            "are-we-there-yet": "1.0.4",
+            "gauge": "1.2.2"
+          },
+          "dependencies": {
+            "ansi": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "0.1.0",
+                "readable-stream": "1.1.13"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "gauge": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi": "0.3.0",
+                "has-unicode": "1.0.1",
+                "lodash.pad": "3.1.1",
+                "lodash.padleft": "3.1.1",
+                "lodash.padright": "3.1.1"
+              },
+              "dependencies": {
+                "lodash.pad": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.padleft": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash._basetostring": "3.0.1",
+                    "lodash._createpadding": "3.6.1"
+                  },
+                  "dependencies": {
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.1"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "has-unicode": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+              "integrity": "sha1-xG/O6gU+uOx4m/+7ol/KUt/c844=",
+              "dev": true
+            }
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "version": "1.3.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.1"
@@ -11821,14 +11657,12 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "1.0.1",
@@ -11837,28 +11671,24 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+              "bundled": true,
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
+          "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "0.0.5"
@@ -11866,16 +11696,14 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2"
@@ -11883,80 +11711,141 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.2",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.2",
             "readdir-scoped-modules": "1.0.2",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "slide": "1.1.6",
             "util-extend": "1.0.1"
           },
           "dependencies": {
             "util-extend": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
-              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
+              "bundled": true,
               "dev": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "graceful-fs": "4.1.2",
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.3.5"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.4",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "json-parse-helpfulerror": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jju": "1.2.1"
+              },
+              "dependencies": {
+                "jju": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.2.tgz",
-          "integrity": "sha1-46SIeS9Az0cIGfAaYQ5xnWTwkJQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "read-package-json": "2.0.12",
+            "once": "1.3.3",
+            "read-package-json": "2.0.2",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+          "version": "2.0.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+            "process-nextick-args": "1.0.6",
             "string_decoder": "0.10.31",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "process-nextick-args": {
-              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
               "dev": true
             },
             "util-deprecate": {
-              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "graceful-fs": "4.1.2",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+            "once": "1.3.3"
+          }
+        },
+        "realize-package-specifier": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3",
+            "npm-package-arg": "4.1.0"
           }
         },
         "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+          "version": "2.67.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
@@ -11966,46 +11855,42 @@
             "extend": "3.0.0",
             "forever-agent": "0.6.1",
             "form-data": "1.0.0-rc3",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "har-validator": "2.0.3",
+            "hawk": "3.1.2",
+            "http-signature": "1.1.0",
+            "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "mime-types": "2.1.8",
+            "node-uuid": "1.4.7",
             "oauth-sign": "0.8.0",
             "qs": "5.2.0",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
           },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true
             },
             "bl": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                "readable-stream": "2.0.5"
               }
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -12013,57 +11898,52 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                "async": "1.5.0",
                 "combined-stream": "1.0.5",
-                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
+                "mime-types": "2.1.8"
               },
               "dependencies": {
                 "async": {
-                  "version": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-                  "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
+                  "version": "1.5.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-              "integrity": "sha1-Wp4SVkpXHPC4Hvk8IVe9FhcWiIM=",
+              "version": "2.0.3",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "1.1.1",
                 "commander": "2.9.0",
-                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                "is-my-json-valid": "2.12.3",
+                "pinkie-promise": "2.0.0"
               },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-styles": "2.1.0",
@@ -12075,20 +11955,17 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.0.0"
@@ -12096,16 +11973,14 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-readlink": "1.0.1"
@@ -12113,33 +11988,30 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                  "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
+                  "version": "2.12.3",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "generate-function": "2.0.0",
                     "generate-object-property": "1.2.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-property": "1.0.2"
@@ -12147,36 +12019,34 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "xtend": {
-                      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "version": "4.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
-                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "version": "2.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    "pinkie": "2.0.1"
                   },
                   "dependencies": {
                     "pinkie": {
-                      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                      "version": "2.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -12184,19 +12054,19 @@
               }
             },
             "hawk": {
-              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "integrity": "sha1-kMkBGIhuIZddGtSumz4oTtGaLeg=",
+              "version": "3.1.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "boom": "2.10.1",
                 "cryptiles": "2.0.5",
                 "hoek": "2.16.3",
                 "sntp": "1.0.9"
               },
               "dependencies": {
                 "boom": {
-                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "version": "2.10.1",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -12204,23 +12074,20 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    "boom": "2.10.1"
                   }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -12229,78 +12096,77 @@
               }
             },
             "http-signature": {
-              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "integrity": "sha1-XS1+m270mYCtWxKNjk7wmjHJDZU=",
+              "version": "1.1.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "assert-plus": "0.1.5",
-                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz"
+                "jsprim": "1.2.2",
+                "sshpk": "1.7.1"
               },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "jsprim": {
-                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "version": "1.2.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
                   },
                   "dependencies": {
                     "extsprintf": {
-                      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "json-schema": {
-                      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "version": "0.2.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "verror": {
-                      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "version": "1.3.6",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        "extsprintf": "1.0.2"
                       }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "integrity": "sha1-Vl44bEKnfmBi+9FMBHL/Ic1TOYw=",
+                  "version": "1.7.1",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    "asn1": "0.2.3",
+                    "assert-plus": "0.2.0",
+                    "dashdash": "1.10.1",
+                    "ecc-jsbn": "0.1.1",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.2"
                   },
                   "dependencies": {
                     "asn1": {
-                      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "version": "0.2.3",
+                      "bundled": true,
                       "dev": true
                     },
                     "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "version": "0.2.0",
+                      "bundled": true,
                       "dev": true
                     },
                     "dashdash": {
-                      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "integrity": "sha1-Cr8a+JqPUSmoHxjCs1sh3yJiL2A=",
+                      "version": "1.10.1",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "assert-plus": "0.1.5"
@@ -12308,39 +12174,38 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "ecc-jsbn": {
-                      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "version": "0.1.1",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jodid25519": {
-                      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jsbn": {
-                      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "version": "0.1.0",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
-                      "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ=",
+                      "version": "0.13.2",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -12349,122 +12214,117 @@
               }
             },
             "is-typedarray": {
-              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
-              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "integrity": "sha1-+vV4I94EvHy/9O6CxrY5RugSrnI=",
+              "version": "2.1.8",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                "mime-db": "1.20.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-                  "integrity": "sha1-SW+Q/QH+DgMciCPsOqlFD/2hjtg=",
+                  "version": "1.20.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-uuid": {
-              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "version": "1.4.7",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+              "bundled": true,
               "dev": true
             },
             "qs": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+              "bundled": true,
               "dev": true
             },
             "stringstream": {
-              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "version": "0.0.5",
+              "bundled": true,
               "dev": true
             },
             "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "version": "2.2.1",
+              "bundled": true,
               "dev": true
             },
             "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "version": "0.4.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "retry": {
           "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
-          "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-          "integrity": "sha1-MMCWzfdy4mvz4dLP+EwhllQam7Y=",
+          "version": "2.5.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz"
+            "glob": "6.0.3"
           },
           "dependencies": {
             "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-              "integrity": "sha1-XwLNiVh85YsVSuCFXeAqLmOYb8o=",
+              "version": "6.0.3",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
               },
               "dependencies": {
                 "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                  "version": "3.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+                    "brace-expansion": "1.1.2"
                   },
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "version": "1.1.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "version": "0.3.0",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
-                          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -12472,8 +12332,8 @@
                   }
                 },
                 "path-is-absolute": {
-                  "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "version": "1.0.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -12481,36 +12341,32 @@
           }
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "version": "5.1.0",
+          "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+            "readable-stream": "2.0.5"
           }
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "sorted-object": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
-          "integrity": "sha1-XR9PnB+yzUiWWWcwTiEutEz7bQU=",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.0.0"
@@ -12518,8 +12374,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.8",
@@ -12529,8 +12384,7 @@
           "dependencies": {
             "block-stream": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-              "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "2.0.1"
@@ -12540,40 +12394,45 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "unique-filename": {
-          "version": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.1",
@@ -12582,8 +12441,7 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
-              "integrity": "sha1-rAdfXy9qBsC/3RyEfrPd492CIeo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-license-ids": "1.0.2"
@@ -12591,8 +12449,7 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
-              "integrity": "sha1-T7t+c4yemPoLCRTf2WGsZin7ze8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-exceptions": "1.0.3",
@@ -12601,24 +12458,21 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
-                  "integrity": "sha1-Oexe0s693wjRgFVdfpnDr/m0dko=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "spdx-license-ids": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-              "integrity": "sha1-BnTpyaIw+YABa1sHOhCqFlcBZ3w=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -12626,15 +12480,14 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
-          "integrity": "sha1-oBDEOq3hp5ij5sGx5FPUXLSXorw=",
+          "version": "1.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-absolute": "0.1.7"
@@ -12642,8 +12495,7 @@
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-relative": "0.1.3"
@@ -12651,8 +12503,7 @@
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -12661,18 +12512,16 @@
         },
         "wrappy": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.2",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
         }
@@ -12686,55 +12535,6 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "semver": "5.4.1"
-      }
-    },
-    "npm-registry-client": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.0.9.tgz",
-      "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
-      "dev": true,
-      "requires": {
-        "chownr": "1.0.1",
-        "concat-stream": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "4.2.1",
-        "npmlog": "2.0.4",
-        "once": "1.4.0",
-        "request": "2.81.0",
-        "retry": "0.8.0",
-        "rimraf": "2.6.1",
-        "semver": "5.4.1",
-        "slide": "1.1.6"
-      },
-      "dependencies": {
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        },
-        "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
-          }
-        }
       }
     },
     "npm-run-path": {
@@ -12817,13 +12617,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-              "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
           }
@@ -12834,29 +12634,18 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
     "object-visit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-      "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
+        "isobject": "3.0.1"
       }
     },
     "object.omit": {
@@ -13137,9 +12926,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "pascalcase": {
@@ -13196,6 +12985,14 @@
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "pend": {
@@ -13205,32 +13002,32 @@
       "dev": true
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "phantomjs-prebuilt": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
-      "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.0.5",
-        "extract-zip": "1.6.5",
+        "es6-promise": "4.1.1",
+        "extract-zip": "1.6.6",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.81.0",
+        "request": "2.83.0",
         "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "which": "1.3.0"
       },
       "dependencies": {
         "es6-promise": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-          "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
           "dev": true
         },
         "fs-extra": {
@@ -13249,22 +13046,13 @@
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
         }
       }
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
@@ -13292,9 +13080,9 @@
       }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "pn": {
@@ -13316,7 +13104,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -13335,14 +13123,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
-      "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+      "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.4.0"
+        "chalk": "2.3.0",
+        "source-map": "0.6.1",
+        "supports-color": "4.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13351,24 +13139,30 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -13395,9 +13189,9 @@
       "dev": true
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.5.2",
@@ -13432,23 +13226,16 @@
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
       "requires": {
         "rsvp": "3.6.2"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        }
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.0",
-        "ipaddr.js": "1.4.0"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -13464,15 +13251,15 @@
       "dev": true
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "quick-temp": {
@@ -13481,7 +13268,7 @@
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
       "requires": {
         "mktemp": "0.4.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "underscore.string": "3.3.4"
       }
     },
@@ -13492,9 +13279,9 @@
       "dev": true
     },
     "qunitjs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-2.4.0.tgz",
-      "integrity": "sha1-WPOoHoRmh/Ln9jfFvtycJn+IcmE=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-2.4.1.tgz",
+      "integrity": "sha512-by/2zYvsNdS6Q6Ev6UJ3qJK+OYVlTzWlQ4afaeYMhVh1dd2K3N1ZZKCrCm3WSWPnz5ELMT8WyJRcVy5PXT2y+Q==",
       "dev": true,
       "requires": {
         "chokidar": "1.6.1",
@@ -13638,7 +13425,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -13688,7 +13475,7 @@
           "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -13701,6 +13488,17 @@
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "range-parser": {
@@ -13710,21 +13508,15 @@
       "dev": true
     },
     "raw-body": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-      "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
-        "bytes": "1.0.0",
-        "string_decoder": "0.10.31"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-          "dev": true
-        }
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
       }
     },
     "read-chunk": {
@@ -13732,19 +13524,6 @@
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
       "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=",
       "dev": true
-    },
-    "read-package-json": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
-      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.1",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
-      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -13846,27 +13625,25 @@
         }
       }
     },
-    "realize-package-specifier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
-      "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3",
-        "npm-package-arg": "4.2.1"
-      }
-    },
     "recast": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.6.tgz",
-      "integrity": "sha1-Sw+4L+sdELO9YtNJQ0Jtmz7TDUw=",
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
+      "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
       "dev": true,
       "requires": {
-        "ast-types": "0.9.11",
+        "ast-types": "0.10.1",
         "core-js": "2.5.1",
         "esprima": "4.0.0",
-        "private": "0.1.7",
-        "source-map": "0.5.7"
+        "private": "0.1.8",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -13897,9 +13674,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator": {
       "version": "0.8.40",
@@ -13910,7 +13687,7 @@
         "commoner": "0.10.8",
         "defs": "1.1.1",
         "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "recast": "0.10.33",
         "through": "2.3.8"
       },
@@ -13935,7 +13712,7 @@
           "requires": {
             "ast-types": "0.8.12",
             "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "source-map": "0.5.7"
           }
         }
@@ -13953,7 +13730,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -13982,7 +13759,7 @@
       "requires": {
         "esprima": "2.7.3",
         "recast": "0.10.43",
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       },
@@ -14007,7 +13784,7 @@
           "requires": {
             "ast-types": "0.8.15",
             "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.7",
+            "private": "0.1.8",
             "source-map": "0.5.7"
           },
           "dependencies": {
@@ -14026,7 +13803,7 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -14077,39 +13854,45 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
+        "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.5",
-        "extend": "3.0.0",
+        "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.0.1"
+        "uuid": "3.1.0"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
@@ -14204,9 +13987,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -14243,12 +14026,6 @@
         "onetime": "1.1.0"
       }
     },
-    "retry": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
-      "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
-      "dev": true
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -14259,21 +14036,21 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
     },
     "rollbar": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.2.7.tgz",
-      "integrity": "sha512-5D4GtIinI36ETbyTIgWqB8IW3U2KqoKDfeRwGn2eJnOkPYSCxgtIFMTS3WNndAI0qrBAZiuw7x5wLpbVoIKZtQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.2.10.tgz",
+      "integrity": "sha512-LJ13UwCj1dwcWaedFPMyRjGfhWB2WkXGNBASFJTVQfa87r9/ramCTQDu+OM3rCWQv+gfEgAVFE6vABz2KKo9DA==",
       "requires": {
         "async": "1.2.1",
         "console-polyfill": "0.3.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "decache": "3.1.0",
         "error-stack-parser": "1.3.3",
         "extend": "3.0.0",
@@ -14291,10 +14068,9 @@
       }
     },
     "rsvp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.0.1.tgz",
-      "integrity": "sha512-EzazW+1W0MqpfPBhApGcKU2xbEuzgs+rO4FvcvuRN1OtLxNFgf9Ce31WGXwGk4VyQQzU8hNyRLjHMzJt+D0STw==",
-      "dev": true
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -14345,7 +14121,7 @@
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
@@ -14425,7 +14201,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
+        "js-base64": "2.3.2",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -14446,44 +14222,36 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        }
       }
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.4"
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
       }
     },
     "set-blocking": {
@@ -14508,21 +14276,21 @@
       "dev": true
     },
     "set-value": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-      "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
         "is-plain-object": "2.0.4",
-        "to-object-path": "0.3.0"
+        "split-string": "3.0.2"
       }
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shebang-command": {
@@ -14558,7 +14326,7 @@
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8"
+        "debug": "2.6.9"
       }
     },
     "simple-dom": {
@@ -14591,16 +14359,21 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.1",
@@ -14608,13 +14381,13 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "0.11.1",
-        "debug": "2.6.8",
+        "base": "0.11.2",
+        "debug": "2.6.9",
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
-        "source-map-resolve": "0.5.0",
+        "source-map-resolve": "0.5.1",
         "use": "2.0.2"
       },
       "dependencies": {
@@ -14635,13 +14408,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -14672,18 +14445,18 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "socket.io": {
@@ -14849,21 +14622,22 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz",
-      "integrity": "sha1-/K0LZLcK+ydpnkJZUMtevNQQvCA=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
         "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
         "urix": "0.1.0"
       }
     },
     "source-map-support": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
-      "integrity": "sha512-30c1Ch8FSjV0FwC253iftbbj0dU/OXoSg1LAEGZJUlGgjTNj6cu+DVqJWWIZJY5RXLWV4eFtR+4ouo0VIOYOTg==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -14875,9 +14649,9 @@
       "dev": true
     },
     "sourcemap-validator": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.0.5.tgz",
-      "integrity": "sha1-+blg9IxkaeKIoZrzBfAF2j3B3zo=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.0.6.tgz",
+      "integrity": "sha1-q9Lx7Nrmo8RsLJbF8lZwWyFHycA=",
       "dev": true,
       "requires": {
         "jsesc": "0.3.0",
@@ -14962,9 +14736,9 @@
       "dev": true
     },
     "split-string": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz",
-      "integrity": "sha1-r0sG2CFWBCZEbDzZMc2mGJQNN9A=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
+      "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
       "dev": true,
       "requires": {
         "extend-shallow": "2.0.1"
@@ -14995,14 +14769,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "stable": {
@@ -15043,13 +14809,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -15212,7 +14978,7 @@
       "integrity": "sha1-omRNaLAjGsAK9DGqFjcU/xcQZEc=",
       "dev": true,
       "requires": {
-        "phantomjs-prebuilt": "2.1.15",
+        "phantomjs-prebuilt": "2.1.16",
         "pn": "1.0.0",
         "yargs": "3.32.0"
       },
@@ -15263,34 +15029,44 @@
       "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -15316,6 +15092,15 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -15326,7 +15111,7 @@
       "dev": true,
       "requires": {
         "events-to-array": "1.1.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "readable-stream": "2.3.3"
       },
       "dependencies": {
@@ -15394,16 +15179,16 @@
       "dev": true,
       "requires": {
         "backbone": "1.3.3",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "charm": "1.0.2",
         "commander": "2.8.1",
         "consolidate": "0.14.5",
         "cross-spawn": "5.1.0",
-        "express": "4.15.4",
+        "express": "4.16.2",
         "fireworm": "0.7.1",
         "glob": "7.1.2",
         "http-proxy": "1.16.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash.assignin": "4.2.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.find": "4.6.0",
@@ -15413,7 +15198,7 @@
         "node-notifier": "5.1.2",
         "npmlog": "4.1.2",
         "printf": "0.2.5",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "socket.io": "1.6.0",
         "spawn-args": "0.2.0",
         "styled_string": "0.0.1",
@@ -15487,11 +15272,11 @@
       "dev": true,
       "requires": {
         "body": "5.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "faye-websocket": "0.10.0",
         "livereload-js": "2.2.2",
         "object-assign": "4.1.1",
-        "qs": "6.5.0"
+        "qs": "6.5.1"
       }
     },
     "tinycolor2": {
@@ -15561,7 +15346,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -15594,13 +15379,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -15616,9 +15401,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
@@ -15635,8 +15420,8 @@
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
       "requires": {
-        "debug": "2.6.8",
-        "fs-tree-diff": "0.5.6",
+        "debug": "2.6.9",
+        "fs-tree-diff": "0.5.7",
         "mkdirp": "0.5.1",
         "quick-temp": "0.1.8",
         "walk-sync": "0.2.7"
@@ -15648,7 +15433,7 @@
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "requires": {
             "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -15775,24 +15560,29 @@
       }
     },
     "union-value": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-      "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
         "arr-union": "3.1.0",
         "get-value": "2.0.6",
         "is-extendable": "0.1.1",
         "set-value": "0.4.3"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "0.1.4"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
       }
     },
     "unique-string": {
@@ -15817,13 +15607,43 @@
       "dev": true
     },
     "unset-value": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-      "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
         "has-value": "0.3.1",
         "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
       }
     },
     "untildify": {
@@ -15878,13 +15698,13 @@
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.0.2.tgz",
-          "integrity": "sha512-ru8+TQHbN8956c7ZlkgK5Imjx0GMat3jN45GNIthpPeb+SzLrqSg/NG7llQtIqUTbrdu5Oi0lSnIoJmDTwwSzw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -15906,9 +15726,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -15936,9 +15756,9 @@
       }
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -15950,14 +15770,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "vinyl": {
@@ -15966,15 +15778,15 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
+        "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
           "dev": true
         }
       }
@@ -15985,7 +15797,7 @@
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "requires": {
         "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.4"
+        "matcher-collection": "1.0.5"
       }
     },
     "walker": {
@@ -16004,18 +15816,19 @@
       "dev": true
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "websocket-extensions": "0.1.1"
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
     "which": {
@@ -16055,9 +15868,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.2.4.tgz",
-      "integrity": "sha512-gE7StiPAOM6318V3EzlR0sFgedAF11PjDZ1xt3SpbuF/vTTDFX2XEnkbFUNqhIHBEKzBDFLPgJSIXyJKP4wZBQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
+      "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
       "requires": {
         "object-assign": "4.1.1"
       }
@@ -16203,7 +16016,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "broccoli-funnel": "2.0.1",
     "ember-cli-babel": "6.8.2",
+    "ember-lodash": "^4.17.5",
+    "git-repo-version": "1.0.0",
     "rollbar": "~2.2.7"
   },
   "devDependencies": {

--- a/tests/unit/config/environment-test.js
+++ b/tests/unit/config/environment-test.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('config:environment', 'Unit | Config | environment', {
+  subject() {
+    return Ember.getOwner(this).resolveRegistration('config:environment');
+  }
+});
+
+test('code_version has been set correctly', function(assert) {
+  let versionRegexp = new RegExp(/^(.+)\+(.{7})$/);
+  let codeVersion = this.subject().emberRollbarClient.payload.client.javascript['code_version'];
+
+  assert.ok(versionRegexp.test(codeVersion));
+});

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -49,16 +49,14 @@ test('debug', function(assert) {
 test('config with default value for code version', function(assert) {
   let service = this.subject();
   let currentVersion = Ember.getOwner(this).resolveRegistration('config:environment').APP.version
-  assert.equal(service.get('config').code_version, currentVersion);
+  assert.equal(service.get('config').payload.client.javascript.code_version, currentVersion);
 });
 
 test('config custom value for code version', function(assert) {
-  let service = this.subject({
-    config: {
-      code_version: '1.2.3'
-    }
-  });
-  assert.equal(service.get('config').code_version, '1.2.3');
+  let emberRollbarClientConfig = Ember.getOwner(this).resolveRegistration('config:environment').emberRollbarClient;
+  emberRollbarClientConfig.payload.client.javascript.code_version = '1.2.3';
+  let service = this.subject();
+  assert.equal(service.get('config').payload.client.javascript.code_version, '1.2.3');
 });
 
 test('registerLogger: register error handler for Ember errors if enabled', function(assert) {

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -46,19 +46,6 @@ test('debug', function(assert) {
   assert.ok(uuid);
 });
 
-test('config with default value for code version', function(assert) {
-  let service = this.subject();
-  let currentVersion = Ember.getOwner(this).resolveRegistration('config:environment').APP.version
-  assert.equal(service.get('config').payload.client.javascript.code_version, currentVersion);
-});
-
-test('config custom value for code version', function(assert) {
-  let emberRollbarClientConfig = Ember.getOwner(this).resolveRegistration('config:environment').emberRollbarClient;
-  emberRollbarClientConfig.payload.client.javascript.code_version = '1.2.3';
-  let service = this.subject();
-  assert.equal(service.get('config').payload.client.javascript.code_version, '1.2.3');
-});
-
 test('registerLogger: register error handler for Ember errors if enabled', function(assert) {
   assert.expect(2);
   let service = this.subject({

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -46,6 +46,21 @@ test('debug', function(assert) {
   assert.ok(uuid);
 });
 
+test('config with default value for code version', function(assert) {
+  let service = this.subject();
+  let currentVersion = Ember.getOwner(this).resolveRegistration('config:environment').APP.version
+  assert.equal(service.get('config').code_version, currentVersion);
+});
+
+test('config custom value for code version', function(assert) {
+  let service = this.subject({
+    config: {
+      code_version: '1.2.3'
+    }
+  });
+  assert.equal(service.get('config').code_version, '1.2.3');
+});
+
 test('registerLogger: register error handler for Ember errors if enabled', function(assert) {
   assert.expect(2);
   let service = this.subject({


### PR DESCRIPTION
Resolves #10

Now you will automatically get the `code_version`, based on the application version. No extra configuration required (but still possible if you like to overwrite it for some reason).

## Remarks

Because `Ember.assign` doesn't support deepMerge well, I had to use "direct" approach.

# Preview
<img width="271" alt="screen shot 2017-11-11 at 11 44 16" src="https://user-images.githubusercontent.com/1891508/32688733-d0518630-c6d6-11e7-83bf-d53f39b1a0b5.png">