### PR TITLE
[Fixes #18] Dynamically set Ember.onerror

### DIFF
--- a/addon/instance-initializers/rollbar.js
+++ b/addon/instance-initializers/rollbar.js
@@ -1,16 +1,7 @@
-import Ember from 'ember';
 
 export function initialize(appInstance) {
   let rollbarService = appInstance.lookup('service:rollbar');
-  let oldOnError = Ember.onerror || function() {};
-
-  Ember.onerror = (...args) => {
-    oldOnError(...args);
-
-    if (rollbarService.get('enabled')) {
-      rollbarService.error(...args);
-    }
-  };
+  rollbarService.registerHandler(rollbarService.get('enabled'));
 }
 
 export default {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-rollbar-client",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/unit/instance-initializers/rollbar-test.js
+++ b/tests/unit/instance-initializers/rollbar-test.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
-import EmberObject from '@ember/object';
 import Application from '@ember/application';
 import { run } from '@ember/runloop';
 import { initialize } from 'dummy/instance-initializers/rollbar';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import RollbarService from 'dummy/services/rollbar';
 
 function createRollbarMock(assert, options = {}) {
-  return EmberObject.extend({
+  return RollbarService.extend({
     enabled: true,
 
     error(message) {
@@ -26,6 +26,7 @@ module('Unit | Instance Initializer | rollbar', {
   },
 
   afterEach() {
+    Ember.onerror = undefined;
     run(this.appInstance, 'destroy');
     destroyApp(this.application);
   },
@@ -37,6 +38,11 @@ test('register error handler for Ember errors', function(assert) {
 
   initialize(this.appInstance);
   Ember.onerror('foo');
+});
+
+test('does not set Ember.onerror if disabled', function(assert) {
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, { enabled: false }));
+  assert.notOk(Ember.onerror);
 });
 
 test('error handler does not override previous hook', function(assert) {
@@ -62,4 +68,4 @@ test('error handler does not fire error if disabled', function(assert) {
 
   initialize(this.appInstance);
   Ember.onerror();
-})
+});

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -1,8 +1,13 @@
 import { moduleFor, test } from 'ember-qunit';
 import Rollbar from 'rollbar';
+import Ember from "ember";
 
 moduleFor('service:rollbar', 'Unit | Service | rollbar', {
-  needs: ['config:environment']
+  needs: ['config:environment'],
+
+  afterEach() {
+    Ember.onerror = undefined;
+  }
 });
 
 test('it exists', function(assert) {
@@ -14,8 +19,9 @@ test('enabled', function(assert) {
   let service = this.subject();
   assert.equal(service.get('enabled'), false);
 
-  service.set('enabled', true)
+  service.set('enabled', true);
   assert.equal(service.get('enabled'), true);
+  assert.ok(Ember.onerror);
   assert.equal(service.get('notifier.options.enabled'), true);
 });
 


### PR DESCRIPTION
This takes a shot at resolving #18. It dynamically sets or clears the `Ember.onerror` handler depending on the state of the `enabled` computed property. Specifically, it will not set `Ember.onerror` (leave it as undefined) if `enabled` is false.