### PR TITLE
New logger mechanism

### DIFF
--- a/addon/instance-initializers/rollbar.js
+++ b/addon/instance-initializers/rollbar.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export function initialize(appInstance) {
-  let rollbarService = appInstance.lookup('service:rollbar');
-  let oldOnError = Ember.onerror || function() {};
+function registerRollbarOnError(rollbarService) {
+  let onError = Ember.onerror;
 
   Ember.onerror = (...args) => {
-    oldOnError(...args);
+    if (typeof onError === 'function') {
+      onError(...args);
+    }
+
     let enabled = rollbarService.get('enabled');
 
     if (enabled) {
@@ -16,6 +18,42 @@ export function initialize(appInstance) {
       throw args[0];
     }
   };
+}
+
+function registerRollbarInLoggers(rollbarService) {
+  let { assert, debug, error, info, warn } = Ember.Logger;
+
+  Ember.Logger.assert = (...args) => {
+    rollbarService.error(...args);
+    assert(...args);
+  }
+
+  Ember.Logger.debug = (...args) => {
+    rollbarService.debug(...args);
+    debug(...args);
+  }
+
+  Ember.Logger.error = (...args) => {
+    rollbarService.error(...args);
+    error(...args);
+  }
+
+  Ember.Logger.info = (...args) => {
+    rollbarService.info(...args);
+    info(...args);
+  }
+
+  Ember.Logger.warn = (...args) => {
+    rollbarService.warning(...args);
+    warn(...args);
+  }
+}
+
+export function initialize(appInstance) {
+  let rollbarService = appInstance.lookup('service:rollbar');
+
+  registerRollbarOnError(rollbarService);
+  registerRollbarInLoggers(rollbarService);
 }
 
 export default { initialize };

--- a/tests/unit/instance-initializers/rollbar-test.js
+++ b/tests/unit/instance-initializers/rollbar-test.js
@@ -75,4 +75,103 @@ test('error handler reacts on enabled state', function(assert) {
   this.appInstance.lookup('service:rollbar').set('enabled', true);
   initialize(this.appInstance);
   assert.throws(() => Ember.onerror(error), error);
-})
+});
+
+test('registers rollbar in error logger', function(assert) {
+  assert.expect(4);
+
+  Ember.Logger.error = function(message) {
+    assert.ok(true);
+    assert.equal(message, 'error');
+  };
+
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, {
+    error(message) {
+      assert.ok(true);
+      assert.equal(message, 'error');
+    }
+  }));
+
+  initialize(this.appInstance);
+
+  Ember.Logger.error('error');
+});
+
+test('registers rollbar in debug logger', function(assert) {
+  assert.expect(4);
+
+  Ember.Logger.debug = function(message) {
+    assert.ok(true);
+    assert.equal(message, 'debug');
+  };
+
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, {
+    debug(message) {
+      assert.ok(true);
+      assert.equal(message, 'debug');
+    }
+  }));
+
+  initialize(this.appInstance);
+  Ember.Logger.debug('debug')
+});
+
+test('registers rollbar in info logger', function(assert) {
+  assert.expect(4);
+
+  Ember.Logger.info = function(message) {
+    assert.ok(true);
+    assert.equal(message, 'info');
+  };
+
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, {
+    info(message) {
+      assert.ok(true);
+      assert.equal(message, 'info');
+    }
+  }));
+
+  initialize(this.appInstance);
+
+  Ember.Logger.info('info')
+});
+
+test('registers rollbar in warn logger', function(assert) {
+  assert.expect(4);
+
+  Ember.Logger.warn = function(message) {
+    assert.ok(true);
+    assert.equal(message, 'warn');
+  };
+
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, {
+    warning(message) {
+      assert.ok(true);
+      assert.equal(message, 'warn');
+    }
+  }));
+
+  initialize(this.appInstance);
+
+  Ember.Logger.warn('warn')
+});
+
+test('registers rollbar in assert logger', function(assert) {
+  assert.expect(4);
+
+  Ember.Logger.assert = function(message, bool) {
+    assert.notOk(bool);
+    assert.equal(message, 'assert');
+  };
+
+  this.appInstance.register('service:rollbar', createRollbarMock(assert, {
+    error(message) {
+      assert.ok(true);
+      assert.equal(message, 'assert');
+    }
+  }));
+
+  initialize(this.appInstance);
+
+  Ember.Logger.assert('assert', false)
+});


### PR DESCRIPTION
This PR will introduce new logger mechanism which is registered to every logger and `onerror` hook.

Now, errors will be always logged to the console no matter in what environment or if Rollbar is enabled. (default behavior of Ember).

Issue: #18 