### PR TITLE
pass all log arguments

### DIFF
--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -40,23 +40,23 @@ export default Service.extend({
 
   // Notifications
 
-  critical(message, data = {}) {
-    return this.get('notifier').critical(message, data);
+  critical(...args) {
+    return this.get('notifier').critical(...args);
   },
 
-  error(message, data = {}) {
-    return this.get('notifier').error(message, data);
+  error(...args) {
+    return this.get('notifier').error(...args);
   },
 
-  warning(message, data = {}) {
-    return this.get('notifier').warning(message, data);
+  warning(...args) {
+    return this.get('notifier').warning(...args);
   },
 
-  info(message, data = {}) {
-    return this.get('notifier').info(message, data);
+  info(...args) {
+    return this.get('notifier').info(...args);
   },
 
-  debug(message, data = {}) {
-    return this.get('notifier').debug(message, data);
+  debug(...args) {
+    return this.get('notifier').debug(...args);
   }
 });


### PR DESCRIPTION
Using this addon I noticed that calling `rollbar.error(someError)` caused only the name of the error to be sent to rollbar.

Looking further into the rollbar documentation I noticed that it says the log methods take multiple arguments

> Note: order does not matter
>
> `message: String` - The message to send to Rollbar.
> `err: Exception` - The exception object to send.
> `custom: Object` - The custom payload data to send to Rollbar.
> `callback: Function` - The function to call once the message has been sent to Rollbar.

By adding `data = {}` as the second argument to the addon log methods, I think its forcing rollbar to interpret the first argument as a string.

My PR attempts to solve it by transparently passing all arguments directly to the corresponding log methods