### PR TITLE
Fix memory leak in Fastboot

### DIFF
--- a/addon/instance-initializers/rollbar.js
+++ b/addon/instance-initializers/rollbar.js
@@ -3,10 +3,8 @@ import Ember from 'ember';
 export function initialize(appInstance) {
   let fastbootService = appInstance.lookup('service:fastboot');
   let rollbarService = appInstance.lookup('service:rollbar');
-  let oldOnError = Ember.onerror || function() {};
 
   Ember.onerror = (...args) => {
-    oldOnError(...args);
     let enabled = rollbarService.get('enabled');
 
     if (enabled) {


### PR DESCRIPTION
The Ember module here is shared across app instances in a Fastboot environment. That means that each new app instance gets the same `Ember` reference here. Because we saved a reference to the old `onError` function, and because the `onError` function closes over a reference to the fastboot and rollbar services, that means that each time this instance initializer ran it retained a reference to an entire app instance that should have been GC'd.

The new `onError` retains the old `onError`, which retains the fastboot & rollbar services, which retain the app instance containers they were instantiated through, which retains basically an entire copy of the app.

Removing the reference to the old `onError` here stops the leak by breaking that retainer chain.