### PR TITLE
Update Rollbar to 2.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19063,14 +19063,12 @@
       }
     },
     "rollbar": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.14.4.tgz",
-      "integrity": "sha512-96m2/pBV8UioBjmqa7/WXiPIcumuuGvmfiB9WHRdVBdHcAuBhYBivWl+NMmS/op2XZ54qAmJyd3uThW6SSKvzQ==",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.19.4.tgz",
+      "integrity": "sha512-8ErcMfJE2zkhgrFtpGRyejHBhyO0hU7dZ3EvG2ylNZ7qSu4yw5PZfhGx+Qyq3ksKshLFeQh9Y/Bh2S1TOPIhvw==",
       "requires": {
         "async": "~1.2.1",
-        "buffer-from": "~1.1.1",
         "console-polyfill": "0.3.0",
-        "debug": "2.6.9",
         "decache": "^3.0.5",
         "error-stack-parser": "^2.0.4",
         "json-stringify-safe": "~5.0.0",
@@ -19969,9 +19967,9 @@
       }
     },
     "stackframe": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
-      "integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "stagehand": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars": "^4.2.0",
     "git-repo-version": "^1.0.2",
     "lodash.merge": "^4.6.1",
-    "rollbar": "~2.14.4"
+    "rollbar": "~2.19.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",


### PR DESCRIPTION
Same as #50, but also updates `rollbar` to 2.19